### PR TITLE
Integrate gfx1151 build hardening from Dillflix fork

### DIFF
--- a/strix-halo/BUILD-FIXES.md
+++ b/strix-halo/BUILD-FIXES.md
@@ -122,6 +122,227 @@ install it when `THEROCK_BUILD_TESTING=OFF`.
 
 **Fix**: Copy `FileCheck` from the build tree to the LLVM bin directory.
 
+### 10b. libhipcxx atomic_codegen gated only on FileCheck
+
+**Symptom**: TheRock configure fails in `math-libs/libhipcxx` with:
+`Could not find cuobjdump using the following names: cuobjdump`
+
+**Root cause**: libhipcxx's `test/atomic_codegen` cmake logic is guarded only
+by whether `FileCheck` exists. On HIP-only ROCm builds, `/usr/bin/FileCheck`
+is present, so cmake enters the CUDA-only atomic codegen test path and then
+hard-requires NVIDIA's `cuobjdump`, aborting configuration.
+
+**Fix**: Replace the `if (filecheck)` guard with
+`if (filecheck AND LIBCUDACXX_ENABLE_CUDA)`, so those tests only configure
+when the CUDA backend is actually enabled.
+
+**Does this involve FileCheck?**: Yes. `FileCheck` is the trigger that causes
+the CUDA-only atomic codegen directory to configure in the first place. The
+fatal missing tool is still `cuobjdump`, but the bad guard is the
+`if (filecheck)` check.
+
+### 10c. roctx64 pre-hooks ignore `THEROCK_ENABLE_PROFILER=OFF`
+
+**Symptom**: TheRock configure fails in RCCL (and potentially rocBLAS or
+rocSPARSE) with:
+`Could not find _therock_legacy_roctx64 using the following names: roctx64`
+
+**Root cause**: Several TheRock pre-hook cmake files unconditionally run a
+legacy `roctx64` link-patch on Linux. Our top-level configuration explicitly
+sets `-DTHEROCK_ENABLE_PROFILER=OFF`, so the profiler stack and `roctx64`
+library are intentionally absent. The pre-hooks should not hard-require
+`roctx64` when profiling is disabled.
+
+**Fix**: Gate the affected Linux pre-hooks on
+`if(NOT WIN32 AND THEROCK_ENABLE_PROFILER)` instead of just `if(NOT WIN32)`.
+This preserves the workaround when the profiler stack is enabled while
+allowing profiler-disabled builds to configure normally.
+
+### 10d. Disable ROCgdb in TheRock configure
+
+**Symptom**: TheRock build later fails in `debug-tools/rocgdb` even though the
+core ROCm compiler/runtime libraries continue building in parallel.
+
+**Root cause**: ROCgdb is an optional ROCm debugger component. It is not needed
+for building or running the vLLM/PyTorch/Triton stack, but TheRock enables it
+by default as part of its debug-tools feature set.
+
+**Fix**: Pass `-DTHEROCK_ENABLE_ROCGDB=OFF` during TheRock configure. This
+skips the optional debugger subproject while preserving the rest of the ROCm
+SDK required by the inference stack.
+
+### 10e. RCCL enables ROCTX even when profiler is disabled
+
+**Symptom**: RCCL configure later fails with:
+`Could not find super-project find_library(NAMES roctx64)`
+
+**Root cause**: RCCL's own cmake enables `ROCTX` by default. When `ROCTX` is
+on, it calls `find_library(roctx64)` and `find_path(roctracer/roctx.h)`.
+That conflicts with this build's `THEROCK_ENABLE_PROFILER=OFF` setting, where
+the profiler stack and `roctx64` are intentionally unavailable.
+
+**Fix**: Inject `-DROCTX=OFF` into TheRock's RCCL subproject cmake args so
+RCCL skips its optional ROCTX tracing path entirely.
+
+### 10f. RCCL rccl_common.h misses tuner macro definitions
+
+**Symptom**: RCCL's `rccl_wrap.cc` fails during the TheRock build with:
+`use of undeclared identifier 'NCCL_NUM_ALGORITHMS'` and
+`use of undeclared identifier 'NCCL_NUM_PROTOCOLS'`
+
+**Root cause**: Newer RCCL snapshots moved `NCCL_NUM_ALGORITHMS` and
+`NCCL_NUM_PROTOCOLS` into `src/include/plugin/nccl_tuner.h`, but
+`src/include/rccl_common.h` still references them after including only
+`nccl_common.h`, `nccl.h`, `param.h`, and `core.h`. In the generated hipify
+header tree that leaves the tuner macros undefined when `rccl_wrap.cc`
+compiles.
+
+**Fix**: Inject `#include "plugin/nccl_tuner.h"` into `rocm-systems/projects/rccl/src/include/rccl_common.h` so the
+internal tuner macro definitions are available before the RCCL addon algorithm
+and protocol declarations.
+
+### 10g. RCCL nvtx.h ignores NVTX stub mode for direct includes
+
+**Symptom**: RCCL's `group.cc` fails during the TheRock build with macro
+redefinition warnings followed by `redefinition of 'nccl_domain'` between
+`nvtx.h` and `nvtx_stub.h`.
+
+**Root cause**: TheRock already passes `-DNVTX_NO_IMPL`, and RCCL's `core.h`
+properly switches to `nvtx_stub.h` in that mode. However, some RCCL sources
+include `nvtx.h` directly, and `nvtx.h` itself does not currently honor
+`NVTX_NO_IMPL`, so both the real NVTX declarations and the stub declarations
+end up active in the same translation unit.
+
+**Fix**: Wrap `rocm-systems/projects/rccl/src/include/nvtx.h` itself in an
+`#ifdef NVTX_NO_IMPL` guard that includes `nvtx_stub.h`, and extend
+`rocm-systems/projects/rccl/src/include/nvtx_stub.h` with a no-op
+`NCCL_NVTX3_FUNC_RANGE` definition so sources using the common NVTX macro
+surface still compile in stub mode.
+
+### 10h. hipBLASLt enables ROCTX markers by default
+
+**Symptom**: hipBLASLt configure fails with:
+`Could not find super-project find_library(NAMES roctx64)`
+
+**Root cause**: hipBLASLt's cmake has `HIPBLASLT_ENABLE_MARKER` enabled by
+default for shared-library builds. When enabled, it calls `find_library(roctx64)`
+and hard-fails if roctracer is absent. That is incompatible with this build's
+`THEROCK_ENABLE_PROFILER=OFF` configuration.
+
+**Fix**: Inject `-DHIPBLASLT_ENABLE_MARKER=OFF` into TheRock's hipBLASLt
+subproject cmake args so it skips the optional ROCTX marker path entirely.
+
+### 10f2. hipSPARSELt enables ROCTX markers by default
+
+**Symptom**: hipSPARSELt configure fails with:
+`Could not find ROCTX64_LIBRARY using the following names: roctx64, libroctx64`
+
+**Root cause**: hipSPARSELt's top-level cmake defines
+`HIPSPARSELT_ENABLE_MARKER` as ON by default on non-Windows builds. When that
+option is enabled, it unconditionally calls `find_library(ROCTX64_LIBRARY ...)`
+and `find_path(roctracer/roctx.h ...)`. That conflicts with this build's
+`THEROCK_ENABLE_PROFILER=OFF` configuration, where roctracer/roctx64 are
+intentionally absent.
+
+**Fix**: Inject `-DHIPSPARSELT_ENABLE_MARKER=OFF` into TheRock's hipSPARSELt
+subproject cmake args so configure skips the optional ROCTX marker path.
+
+### 10f3. MIOpen still probes roctracer headers when profiler is disabled
+
+**Symptom**: MIOpen configure fails with:
+`Could not find super-project find_path(NAMES roctracer/roctx.h)`
+
+**Root cause**: MIOpen's top-level `CMakeLists.txt` sets
+`MIOPEN_USE_ROCTRACER` to `ON` by default. On non-Windows builds that makes
+configure call `find_path(roctracer/roctx.h)` and `find_library(roctx64)`,
+which conflicts with this build's `THEROCK_ENABLE_PROFILER=OFF`
+configuration where roctracer/roctx64 are intentionally absent.
+
+**Fix**: Inject `-DMIOPEN_USE_ROCTRACER=OFF` into TheRock's MIOpen subproject
+cmake args so the optional rocTracer/ROCTX probe is skipped entirely.
+
+### 10g. rocprofiler-sdk yaml-cpp patch path moved in current TheRock layout
+
+**Symptom**: rocprofiler-sdk later fails compiling vendored yaml-cpp with
+undeclared `uint16_t` / `uint32_t` in `external/yaml-cpp/src/emitterutils.cpp`.
+
+**Root cause**: The source patch for yaml-cpp's missing `<cstdint>` include was
+targeting an old path layout and no longer matched the current TheRock source
+tree. As a result, the workaround never applied.
+
+**Fix**: Update the patch target path to
+`rocm-systems/projects/rocprofiler-sdk/external/yaml-cpp/src/emitterutils.cpp`
+so the existing `<cstdint>` insertion applies to the actual vendored file.
+
+### 10h. rocBLAS still probes roctracer headers when profiler is disabled
+
+**Symptom**: rocBLAS configure fails with:
+`Could not find super-project find_path(... roctracer/roctx.h ...)`
+even though TheRock already passes `-DROCTX=OFF` to the rocBLAS subproject.
+
+**Root cause**: rocBLAS's `projects/rocblas/library/CMakeLists.txt` gates the
+ROCTX probe only on `BUILD_SHARED_LIBS`. Its `find_path(roctracer/roctx.h)` and
+`find_library(roctx64)` block does not honor the `ROCTX` cache option, so the
+header/library probe still runs in shared-library builds even when profiling is
+explicitly disabled.
+
+**Fix**: Keep injecting `-DROCTX=OFF` from TheRock's `math-libs/BLAS/CMakeLists.txt`,
+and patch `rocm-libraries/projects/rocblas/library/CMakeLists.txt` in two ways:
+first, guard the ROCTX probe with `if(BUILD_SHARED_LIBS AND ROCTX)` instead of
+only `if(BUILD_SHARED_LIBS)`; second, add `target_compile_definitions(... DISABLE_ROCTX)`
+when `ROCTX` is off so sources like `logging.cpp` do not include
+`<roctracer/roctx.h>` after the probe has been skipped.
+
+
+### 10h2. rocSPARSE still probes roctracer headers unless BUILD_WITH_ROCTX is turned off
+
+**Symptom**: rocSPARSE configure fails with:
+`Could not find super-project find_path(... roctracer/roctx.h ...)`
+
+**Root cause**: Unlike rocBLAS, rocSPARSE already has an upstream
+`if(BUILD_SHARED_LIBS AND BUILD_WITH_ROCTX)` guard around its ROCTX probing in
+`projects/rocsparse/library/CMakeLists.txt`. However, TheRock's
+`math-libs/BLAS/CMakeLists.txt` does not pass `-DBUILD_WITH_ROCTX=OFF` to the
+rocSPARSE subproject, so the guarded probe still stays enabled by default and
+hits the explicit super-project finder when profiler components are absent.
+
+**Fix**: Inject `-DBUILD_WITH_ROCTX=OFF` into TheRock's rocSPARSE subproject
+cmake args so rocSPARSE skips the optional roctx header/library probe entirely.
+
+### 10i. ROCR-Runtime OpenCL blit kernels do not know the device-lib path while bootstrapping
+
+**Symptom**: TheRock build fails in `rocm-systems/projects/rocr-runtime` while
+building `opencl_blit_objects` with a command like:
+`clang -O2 -x cl ... imageblit_kernels.cl`
+followed by:
+`cannot find ROCm device library; provide its path via '--rocm-path' or '--rocm-device-lib-path'`
+
+**Root cause**: `runtime/hsa-runtime/image/blit_src/CMakeLists.txt` hard-codes
+a `clang -x cl` custom command for the OpenCL blit kernels, but it does not
+pass any ROCm install root or device-library path. During a TheRock bootstrap
+build, clang cannot infer the just-built `amdgcn/bitcode` directory on its own,
+so current clang releases abort instead of compiling the embedded blit objects.
+
+**Fix**: Patch `rocm-systems/projects/rocr-runtime/runtime/hsa-runtime/image/blit_src/CMakeLists.txt`
+to detect `${CMAKE_PREFIX_PATH}/llvm/amdgcn/bitcode` or
+`${CMAKE_PREFIX_PATH}/amdgcn/bitcode` and append
+`--rocm-device-lib-path=<detected path>` to the generated `clang -x cl` command.
+
+### 25b. YAML patchelf RPATH expansion treated `$ORIGIN` as a shell variable
+
+**Symptom**: `build-vllm.sh` aborts while applying `patchelf_rpath` patches
+with:
+`./build-vllm.sh: line 754: ORIGIN: unbound variable`
+
+**Root cause**: The YAML-driven patch helper expanded RPATH templates with
+`eval echo`. That works for `${LOCAL_PREFIX}` but also tries to expand ELF
+loader tokens like `$ORIGIN` as shell variables, which fails under
+`set -u`.
+
+**Fix**: Escape `$ORIGIN` before running `eval echo` so shell variable
+expansion still resolves our repo variables while preserving the literal ELF
+RPATH token for `patchelf`.
+
 ## AOCL-LibM (Phase B, Step 6)
 
 ### 11. -muse-unaligned-vector-move (AOCC-only flag)
@@ -209,12 +430,15 @@ namespace declaration and a comment explaining the removal.
 **Symptom**: Undefined symbol errors at link time (e.g., `const_data_ptr<Half>`
 mangled differently between `libtorch_cpu.so` and `libtorch_hip.so`).
 
-**Root cause**: PyTorch's `cmake/Dependencies.cmake` adds
-`-fclang-abi-compat=17` to HIPCC flags "for compat with newer hip-clang C++20
-mangling rules". This forces HIP device code to use Clang 17 ABI while host
-code uses amdclang 22 ABI, causing name mangling mismatches.
+**Root cause**: PyTorch's ROCm build injects `-fclang-abi-compat=17` in two
+places: top-level host flags in `CMakeLists.txt` and HIP flags in
+`cmake/Dependencies.cmake`. On current amdclang releases that Clang 17 ABI
+override can still leave host/HIP objects mangled inconsistently, producing
+undefined symbols between `libtorch_cpu.so` and `libtorch_hip.so`.
 
-**Fix**: Remove the `-fclang-abi-compat=17` line from `Dependencies.cmake`.
+**Fix**: Remove both `-fclang-abi-compat=17` injections — the host-side
+`append_cxx_flag_if_supported(... CMAKE_CXX_FLAGS)` line in `CMakeLists.txt`
+and the HIPCC line in `cmake/Dependencies.cmake`.
 
 ### 19. Missing librocm_smi64.so linkage (upstream bug)
 
@@ -329,7 +553,24 @@ build tree references:
 patchelf --set-rpath '/opt/src/vllm/local/lib:$ORIGIN' torch/lib/libtorch_python.so
 ```
 
-### 25c. NumPy 2.0 ABI target version
+### 25c. Validation retry for stale installed torch artifacts
+
+**Symptom**: Step 12 (`Validate PyTorch GPU access`) fails on `import torch`
+with `libtorch_hip.so: undefined symbol: _ZN2at4cuda4blas4gemm...` even
+though the wheel was rebuilt from a clean `build/` directory.
+
+**Root cause**: In some failed/retried builds, the virtualenv can still hold
+stale `torch/`, `torch-*.dist-info`, or `functorch/` artifacts from an older
+install. When Python resolves mixed old/new extension modules from the same
+environment, `libtorch_hip.so` can be loaded without the matching symbol
+provider from the rebuilt wheel.
+
+**Fix**: During validation, detect this exact unresolved-symbol import
+failure, remove old torch artifacts from the active site-packages directory,
+reinstall the newest locally built torch wheel with `uv pip install
+--force-reinstall --no-deps`, and retry the import once before failing.
+
+### 25d. NumPy 2.0 ABI target version
 
 **Symptom**: `import torch` crashes with "A module that was compiled using
 NumPy 1.x cannot be run in NumPy 2.4.3".
@@ -342,6 +583,30 @@ check when loaded with numpy >= 2.0.
 **Fix**: Patch `torch/csrc/utils/numpy_stub.h` to set `NPY_TARGET_VERSION`
 before including `<numpy/arrayobject.h>`:
 
+### 25e. Missing OpenMP runtime linkage in libtorch_cpu.so
+
+**Symptom**: `import torch` fails immediately with:
+
+```text
+ImportError: .../torch/lib/libtorch_cpu.so: undefined symbol: __kmpc_fork_call
+```
+
+**Root cause**: PyTorch was built with clang/amdclang OpenMP enabled, so
+`libtorch_cpu.so` references the `__kmpc_*` entry points provided by LLVM's
+OpenMP runtime (`libomp.so` / `libiomp5.so`). In some builds the packaged wheel
+omits that runtime from `libtorch_cpu.so`'s `NEEDED` list, so the dynamic
+linker never loads it during `import torch`.
+
+**Fix**: Do **not** rewrite PyTorch's internal ELF dependency graph to force in
+an OpenMP runtime. That proved brittle and could trigger follow-on import
+failures in `libtorch_hip.so`. Instead, preload LLVM's OpenMP runtime from the
+environment whenever it exists under `${LOCAL_PREFIX}/lib/llvm/lib` or
+`${LOCAL_PREFIX}/lib`:
+
+```bash
+export LD_PRELOAD=/opt/src/vllm/local/lib/llvm/lib/libomp.so${LD_PRELOAD:+:$LD_PRELOAD}
+```
+
 ```c
 #ifndef NPY_TARGET_VERSION
 #define NPY_TARGET_VERSION 0x00000012  /* NPY_2_0_API_VERSION */
@@ -350,6 +615,24 @@ before including `<numpy/arrayobject.h>`:
 
 The hex value must be used directly because `NPY_2_0_API_VERSION` is defined
 inside `numpyconfig.h` which is included by `arrayobject.h`.
+
+### 25d. PyTorch wheel misses the LLVM OpenMP runtime path/dependency
+
+**Symptom**: `import torch` fails immediately with:
+`ImportError: .../libtorch_cpu.so: undefined symbol: __kmpc_fork_call`
+
+**Root cause**: The source-built PyTorch wheel is compiled with amdclang's
+OpenMP runtime, but the packaged wheel patching only added
+`${LOCAL_PREFIX}/lib` to RPATH and only injected `librocm_smi64.so` into
+`libtorch_hip.so`. The OpenMP runtime lives under
+`${LOCAL_PREFIX}/lib/llvm/lib`, and some wheel builds also leave
+`libtorch_cpu.so` without an explicit `libomp.so` NEEDED entry. That leaves
+the `__kmpc_*` symbols unresolved at import time.
+
+**Fix**: During the unpack/patch/repack step, rewrite PyTorch wheel RPATHs to
+include both `${LOCAL_PREFIX}/lib` and `${LOCAL_PREFIX}/lib/llvm/lib`, and add
+`libomp.so` to `libtorch_cpu.so` when it still exports unresolved
+`__kmpc_fork_call` without an existing `libomp` dependency.
 
 ## TorchVision (Phase C, Steps 12-13)
 
@@ -560,21 +843,21 @@ pass as a single HIPGraph) combined with ALL AITER optimizations
 (attention, GEMM, normalization). Previously, the `+rms_norm` bug forced
 PIECEWISE graph mode with AITER disabled.
 
-### 41. Triton sampler page fault on gfx1151 (Patch 10)
+### 41. Triton sampler page fault on gfx1151 (historical, build-specific)
 
-**Symptom**: GPU page fault during top-k/top-p sampling after torch.compile
-AOT compilation on RDNA 3.5.
+**Symptom**: Some builds observed GPU page faults during top-k/top-p sampling
+after torch.compile AOT compilation on RDNA 3.5.
 
-**Root cause**: The Triton top-k/top-p sampler kernel
-(`apply_top_k_top_p_triton`) page-faults on gfx1151 after ahead-of-time
-compilation by torch.compile. The kernel works in eager mode but the
-compiled version triggers an illegal memory access on RDNA 3.5's wave32
-architecture.
+**Root cause**: This is not a universal hardware limitation. It is a stack
+compatibility issue (specific vLLM/PyTorch/Triton/AITER combinations and
+cached compile artifacts), where the compiled sampler path can diverge from
+its eager behavior. On other builds of the same hardware/OS, the Triton
+sampler works correctly.
 
-**Fix**: Bypass the Triton sampler in
-`vllm/v1/sample/ops/topk_topp_sampler.py`. The PyTorch sort-based path
-(`topk` + `cumsum`) is functionally identical and works on all
-architectures.
+**Current approach**: Do **not** hard-disable Triton sampler in the build
+patch set. Keep upstream behavior by default and treat sampler faults as an
+investigation target (version skew, patch skew, stale compile cache, and
+backend selection), not a blanket architecture rule.
 
 ### 42. FLA chunk_delta_h autotuner + exp() type inference (Patches 11-15)
 

--- a/strix-halo/CHANGELOG.md
+++ b/strix-halo/CHANGELOG.md
@@ -33,7 +33,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   CDNA-only modules with failure reasons (async LDS DMA, packed FP8, wave64
   static_assert, backward codegen, etc.). Maintainable — remove entries if
   upstream AITER adds gfx1151 support.
-- **Backend smoke test** (step 36): Downloads SmolLM2-135M-Instruct (~270 MB
+- **Backend smoke test** (step 37): Downloads SmolLM2-135M-Instruct (~270 MB
   FP16, ~70 MB Q4 GGUF) and runs actual inference through all five backends:
   vLLM, llama.cpp ROCm, llama.cpp Vulkan, Lemonade SDK, and Ollama.
   TunableOp GEMM warmup occurs as a side effect of the vLLM test, so the
@@ -61,14 +61,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **YAML-driven build pipeline**: All 36 build steps across 10 phases (A–J)
+- **YAML-driven build pipeline**: All 37 build steps across 10 phases (A–J)
   are now orchestrated from `vllm-packages.yaml`. Repository URLs, branches,
   patches, build flags, and prerequisites are declared in YAML and read at
   runtime via `yq`. The build script is a generic executor, not a hardcoded
   sequence.
 - **TunableOp warmup absorbed into smoke test**: The standalone
   `warmup_tunableop()` (former step 29c) is replaced by the backend smoke
-  test (step 36). TunableOp CSV is populated as a side effect of vLLM
+  test (step 37). TunableOp CSV is populated as a side effect of vLLM
   inference — no `.env` file or pre-configured model required.
 - **Prerequisites section** in `vllm-packages.yaml` restructured with per-distro
   `install_commands` map (arch, ubuntu, fedora) instead of a single Arch-only
@@ -140,9 +140,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   speedup (137 -> 1060 tok/s on Qwen2.5-0.5B).
 - **Duplicate pattern registration crash** (BUILD-FIXES.md #39): AITER fusion
   pass registered identical patterns, fixed with `skip_duplicates=True`.
-- **Triton sampler page fault** (BUILD-FIXES.md #41): Triton top-k/top-p kernel
-  page-faults on gfx1151 after torch.compile AOT. Bypassed to PyTorch
-  sort-based path.
+- **Triton sampler page fault** (BUILD-FIXES.md #41): Reframed as a
+  build-specific stack-compatibility issue (not a universal gfx1151 rule).
+  Removed the blanket sampler-bypass patch from the YAML patch set so
+  Triton sampler remains enabled by default.
 - **FLA autotuner page faults** (BUILD-FIXES.md #42, #49): Restricted AMD
   autotuning to `num_stages=2`, `BV=32` to stay within RDNA 3.5 register
   pressure limits.

--- a/strix-halo/README.md
+++ b/strix-halo/README.md
@@ -74,53 +74,57 @@ that force PIECEWISE graph mode with AITER disabled.
    flag (proprietary Zen microarchitecture tuning not available in
    upstream LLVM).
 
-## Build Pipeline (35 Steps, 9 Phases)
+## Build Pipeline (37 Steps, 10 Phases)
 
 ```
 Phase A: ROCm SDK (TheRock)
-  1. Clone TheRock          3. Build TheRock (~3 hours)
-  2. Configure TheRock      4. Validate ROCm
+  1. Clone TheRock          4. Build TheRock (~3 hours)
+  2. Create bootstrap venv  5. Validate ROCm
+  3. Configure TheRock
 
 Phase B: CPU Libraries + Python
-  5. Build AOCL-Utils       7. Build Python 3.13 (PGO + LTO)
-  6. Build AOCL-LibM        8. Create venv
+  6. Build AOCL-Utils       8. Build Python 3.13 (PGO + LTO)
+  7. Build AOCL-LibM        9. Create final venv
 
 Phase C: ML Framework (PyTorch + TorchVision)
-  9. Clone PyTorch         12. Clone TorchVision
- 10. Build PyTorch (~1-2h) 13. Build TorchVision
- 11. Validate PyTorch
+ 10. Clone PyTorch         13. Clone TorchVision
+ 11. Build PyTorch (~1-2h) 14. Build TorchVision
+ 12. Validate PyTorch
 
 Phase D: Kernel Compilers
- 14. Clone Triton          17. Clone AOTriton
- 15. Build Triton          18. Build AOTriton
- 16. Validate Triton
+ 15. Clone Triton          18. Clone AOTriton
+ 16. Build Triton          19. Build AOTriton
+ 17. Validate Triton
 
 Phase E: Inference Engine
- 19. Clone vLLM            23. Install ROCm requirements
- 20. Patch amdsmi import   24. Build vLLM (AITER first)
- 20b. Patch gfx1151 AITER
- 21. Install build deps
- 22. use_existing_torch.py
+ 20. Clone vLLM            24. Install ROCm requirements
+ 21. Patch amdsmi import   25. Build vLLM (AITER first)
+ 21b. Patch gfx1151 AITER
+ 22. Install build deps
+ 23. use_existing_torch.py
 
 Phase F: Attention (Flash Attention + AITER)
- 25. Reinstall amdsmi      28. Build Flash Attention
- 26. Clone Flash Attention  28b. Rebuild AITER from source (CK-aligned)
- 27. Patch Flash Attention
+ 26. Reinstall amdsmi      29. Build Flash Attention
+ 27. Clone Flash Attention  29b. Rebuild AITER from source (CK-aligned)
+ 28. Patch Flash Attention
 
 Phase G: Validation + Warmup
- 29. Smoke test
- 29b. AITER JIT pre-warm   (compile all buildable modules ahead of time)
- 29c. TunableOp warmup     (populate GEMM autotuning CSV)
+ 30. Smoke test
+ 30b. AITER JIT pre-warm   (compile all buildable modules ahead of time)
+ 30c. TunableOp warmup     (populate GEMM autotuning CSV)
 
 Phase H: Optimized Wheels (Zen 5 native builds for downstream venvs)
- 30. Build Rust wheels     (orjson, cryptography — AVX-512 + VAES)
- 31. Build C/C++ wheels    (numpy, sentencepiece, zstandard, asyncpg)
- 32. Export source wheels   (torch, triton, torchvision, amd-aiter, amdsmi)
+ 31. Build Rust wheels     (orjson, cryptography — AVX-512 + VAES)
+ 32. Build C/C++ wheels    (numpy, sentencepiece, zstandard, asyncpg)
+ 33. Export source wheels   (torch, triton, torchvision, amd-aiter, amdsmi)
 
 Phase I: Lemonade Inference Server
- 33. Clone Lemonade + build llama.cpp (ROCm hipBLAS + Vulkan backends)
- 34. Install Lemonade SDK from PyPI
- 35. Validate Lemonade (both backends)
+  34. Clone Lemonade + build llama.cpp (ROCm hipBLAS + Vulkan backends)
+  35. Install Lemonade SDK from PyPI
+  36. Validate Lemonade (both backends)
+
+Phase J: Backend Smoke Test
+  37. Validate all inference backends with SmolLM2
 ```
 
 ### Lemonade: Dual-Backend llama.cpp
@@ -152,7 +156,14 @@ prerequisite checks and install hints accordingly.
 `uv` and `yq` are **auto-bootstrapped** if not found on PATH. The script
 tries `go install` first (always gets latest), then falls back to
 downloading the latest release binary from GitHub. Both tools are also
-installed into the venv for self-contained builds.
+installed into the managed bootstrap/final venvs for self-contained builds.
+
+
+The build now creates a **bootstrap virtual environment** from `python3` before
+TheRock configuration/build begins, so every early `uv pip install` happens
+inside a managed env instead of leaking packages into the system interpreter.
+After step 8 compiles the optimized CPython, step 9 recreates the canonical
+vLLM environment on `/opt/src/vllm/python/bin/python3`.
 
 ## Quick Start
 
@@ -239,7 +250,7 @@ all 40+ target features including AVX-512, VAES, VPCLMULQDQ, GFNI, SHA.
 
 | File | Description |
 |------|-------------|
-| `build-vllm.sh` | Master build script (36-step pipeline) |
+| `build-vllm.sh` | Master build script (37-step pipeline) |
 | `vllm-env.sh` | Environment activation (compiler flags, ROCm paths, venv) |
 | `vllm-packages.yaml` | Package manifest (repos, branches, patches, per-distro prerequisites, bootstrap config) |
 | `vllm-start.sh` | Start all vLLM inference instances (role-based, multi-model) |

--- a/strix-halo/build-vllm.sh
+++ b/strix-halo/build-vllm.sh
@@ -29,51 +29,55 @@
 #   scripts/build-vllm.sh --rebuild   # Force rebuild (clean + build)
 #   scripts/build-vllm.sh --step N    # Run from step N onward
 #
-# Build pipeline (35 steps):
+# Build pipeline (37 steps):
 #   Phase A: ROCm SDK (TheRock — builds amdclang used by everything downstream)
-#     1. Clone TheRock          3. Build TheRock
-#     2. Configure TheRock      4. Validate ROCm
+#     1. Clone TheRock          4. Build TheRock
+#     2. Create bootstrap venv  5. Validate ROCm
+#     3. Configure TheRock
 #
 #   Phase B: CPU Libraries + Python (built with amdclang from Phase A)
-#     5. Build AOCL-Utils       7. Build Python 3.13
-#     6. Build AOCL-LibM        8. Create venv
+#     6. Build AOCL-Utils       8. Build Python 3.13
+#     7. Build AOCL-LibM        9. Create final venv
 #
 #   Phase C: ML Framework (PyTorch + TorchVision, ROCm fork)
-#     9. Clone PyTorch         12. Clone TorchVision
-#    10. Build PyTorch         13. Build TorchVision
-#    11. Validate PyTorch
+#    10. Clone PyTorch         13. Clone TorchVision
+#    11. Build PyTorch         14. Build TorchVision
+#    12. Validate PyTorch
 #
 #   Phase D: Kernel Compilers (Triton + AOTriton)
-#    14. Clone Triton          17. Clone AOTriton
-#    15. Build Triton          18. Build AOTriton
-#    16. Validate Triton
+#    15. Clone Triton          18. Clone AOTriton
+#    16. Build Triton          19. Build AOTriton
+#    17. Validate Triton
 #
 #   Phase E: Inference Engine (vLLM)
-#    19. Clone vLLM             23. Install ROCm requirements
-#    20. Patch amdsmi import    24. Build vLLM (AITER first)
-#    20b. Patch gfx1151 AITER
-#    21. Install build deps
-#    22. use_existing_torch.py
+#    20. Clone vLLM             24. Install ROCm requirements
+#    21. Patch amdsmi import    25. Build vLLM (AITER first)
+#    21b. Patch gfx1151 AITER
+#    22. Install build deps
+#    23. use_existing_torch.py
 #
 #   Phase F: Attention (Flash Attention + AITER)
-#    25. Reinstall amdsmi      28. Build Flash Attention
-#    26. Clone Flash Attention  28b. Rebuild AITER from source (CK-aligned)
-#    27. Patch Flash Attention
+#    26. Reinstall amdsmi      29. Build Flash Attention
+#    27. Clone Flash Attention  29b. Rebuild AITER from source (CK-aligned)
+#    28. Patch Flash Attention
 #
 #   Phase G: Validation + Warmup
-#    29. Smoke test
-#    29b. AITER JIT pre-warm (compile all buildable modules ahead of time)
-#    29c. TunableOp warmup (populate GEMM autotuning CSV)
+#    30. Smoke test
+#    30b. AITER JIT pre-warm (compile all buildable modules ahead of time)
+#    30c. TunableOp warmup (populate GEMM autotuning CSV)
 #
 #   Phase H: Optimized Wheels (Zen 5 native builds for downstream venvs)
-#    30. Build Rust wheels      (orjson, cryptography — AVX-512 + VAES)
-#    31. Build C/C++ wheels     (numpy, sentencepiece, zstandard, asyncpg, duckdb)
-#    32. Export source wheels    (torch, triton, torchvision, amd-aiter, amdsmi)
+#    31. Build Rust wheels      (orjson, cryptography — AVX-512 + VAES)
+#    32. Build C/C++ wheels     (numpy, sentencepiece, zstandard, asyncpg, duckdb)
+#    33. Export source wheels    (torch, triton, torchvision, amd-aiter, amdsmi)
 #
 #   Phase I: Lemonade Inference Server (llama.cpp + FLM + ONNX)
-#    33. Clone Lemonade + build llama.cpp with hipBLAS for gfx1151
-#    34. Install Lemonade SDK from PyPI (lemonade-sdk)
-#    35. Validate Lemonade (server smoke test)
+#    34. Clone Lemonade + build llama.cpp with hipBLAS for gfx1151
+#    35. Install Lemonade SDK from PyPI (lemonade-sdk)
+#    36. Validate Lemonade (server smoke test)
+#
+#   Phase J: Backend Smoke Test
+#    37. Backend smoke test (all inference backends)
 
 set -euo pipefail
 
@@ -132,6 +136,124 @@ detect_distro() {
 }
 
 detect_distro
+
+configure_openmp_runtime_env() {
+    local _runtime_root="${1:-${ROCM_PATH:-${LOCAL_PREFIX:-}}}"
+    local _candidate
+    for _candidate in \
+        "${_runtime_root}/lib/llvm/lib/libomp.so" \
+        "${_runtime_root}/lib/llvm/lib/libiomp5.so" \
+        "${_runtime_root}/lib/libomp.so" \
+        "${_runtime_root}/lib/libiomp5.so"; do
+        [[ -f "${_candidate}" ]] || continue
+        case ":${LD_PRELOAD:-}:" in
+            *:"${_candidate}":*) return 0 ;;
+        esac
+        export LD_PRELOAD="${_candidate}${LD_PRELOAD:+:${LD_PRELOAD}}"
+        return 0
+    done
+}
+
+is_known_pytorch_rocm_import_failure() {
+    local _log_file="${1}"
+    [[ -f "${_log_file}" ]] || return 1
+    grep -q 'libtorch_hip.so: undefined symbol: _ZN2at4cuda4blas4gemm' "${_log_file}"
+}
+
+diagnose_pytorch_import_failure() {
+    local _log_file="${1}"
+    [[ -f "${_log_file}" ]] || return 0
+
+    if is_known_pytorch_rocm_import_failure "${_log_file}"; then
+        warn "Detected libtorch_hip.so unresolved at::cuda::blas::gemm symbol."
+        warn "This is a PyTorch ROCm import failure; the validator will attempt one clean wheel reinstall before giving up."
+        warn "Environment: LD_PRELOAD=${LD_PRELOAD:-<unset>}"
+        warn "Environment: LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-<unset>}"
+        if [[ -f "${PYTORCH_SRC}/cmake/Dependencies.cmake" ]]; then
+            if grep -q -- '-fclang-abi-compat=17' "${PYTORCH_SRC}/cmake/Dependencies.cmake"; then
+                warn "Potential cause: cmake/Dependencies.cmake still contains -fclang-abi-compat=17."
+            else
+                warn "Checked ${PYTORCH_SRC}/cmake/Dependencies.cmake: -fclang-abi-compat=17 is NOT present."
+            fi
+        fi
+
+        local _hip_path _torch_lib_dir _torch_root _c_ext _ld_debug_log _saved_ld_debug_log
+        _hip_path="$(grep -o '/[^ :]*libtorch_hip\.so' "${_log_file}" | head -n 1 || true)"
+        if [[ -n "${_hip_path}" && -f "${_hip_path}" ]]; then
+            _torch_lib_dir="$(dirname "${_hip_path}")"
+            _torch_root="$(dirname "${_torch_lib_dir}")"
+            _c_ext="$(find "${_torch_root}" -maxdepth 1 -name '_C*.so' | head -n 1 || true)"
+            warn "libtorch_hip.so dynamic section:"
+            readelf -d "${_hip_path}" | grep 'NEEDED\|RPATH\|RUNPATH' || true
+            if command -v ldd >/dev/null 2>&1; then
+                warn "ldd for libtorch_hip.so:"
+                ldd "${_hip_path}" || true
+                if [[ -n "${_c_ext}" && -f "${_c_ext}" ]]; then
+                    warn "ldd for $(basename "${_c_ext}"):"
+                    ldd "${_c_ext}" || true
+                fi
+            fi
+            if command -v nm >/dev/null 2>&1; then
+                warn "Searching installed torch shared libraries for the missing gemm symbol definition..."
+                find "${_torch_root}" -maxdepth 2 -name '*.so' -print0 | while IFS= read -r -d '' _lib; do
+                    if nm -D --defined-only "${_lib}" 2>/dev/null | grep -q '_ZN2at4cuda4blas4gemm'; then
+                        warn "  provider candidate: ${_lib}"
+                    fi
+                done
+            fi
+
+            _ld_debug_log="$(mktemp)"
+            if LD_DEBUG=libs,symbols python -c 'import torch' > /dev/null 2>"${_ld_debug_log}"; then
+                warn "LD_DEBUG import unexpectedly succeeded during diagnostics."
+            else
+                warn "Captured loader trace for failing import."
+                grep -E 'libtorch_hip|_ZN2at4cuda4blas4gemm|symbol lookup error|calling init|find library=' "${_ld_debug_log}" | tail -n 200 || true
+                if [[ -n "${VLLM_DIR:-}" && -d "${VLLM_DIR}" ]]; then
+                    _saved_ld_debug_log="${VLLM_DIR}/torch-import-ld-debug.log"
+                    cp "${_ld_debug_log}" "${_saved_ld_debug_log}"
+                    warn "Full LD_DEBUG trace saved to ${_saved_ld_debug_log}"
+                fi
+            fi
+            rm -f "${_ld_debug_log}"
+        fi
+    fi
+}
+
+retry_pytorch_wheel_install() {
+    local _torch_wheel
+    _torch_wheel="$(newest_wheel "${WHEELS_DIR}"/torch-*.whl)"
+    if [[ -z "${_torch_wheel}" ]]; then
+        warn "Cannot retry PyTorch import recovery: no torch wheel found in ${WHEELS_DIR}"
+        return 1
+    fi
+
+    warn "Retrying PyTorch install from wheel after known ROCm import failure..."
+    python - <<'PY'
+import pathlib
+import shutil
+import site
+
+removed = []
+for base in site.getsitepackages() + [site.getusersitepackages()]:
+    root = pathlib.Path(base)
+    if not root.exists():
+        continue
+    for pattern in ("torch", "torch-*.dist-info", "torch-*.egg-info", "functorch"):
+        for path in root.glob(pattern):
+            if not path.exists():
+                continue
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                path.unlink(missing_ok=True)
+            removed.append(str(path))
+
+print("Removed old torch artifacts:" if removed else "No old torch artifacts found.")
+for item in removed:
+    print(f"  {item}")
+PY
+    uv pip install --force-reinstall --no-deps "${_torch_wheel}"
+}
 
 # =============================================================================
 # YAML Manifest Helpers
@@ -383,7 +505,7 @@ bootstrap_tools() {
 }
 
 # Install uv and yq into the venv's bin/ for self-contained builds.
-# Called during create_venv() after the venv is created and activated.
+# Called after a managed venv is created and activated.
 install_tools_to_venv() {
     local venv_bin="${VLLM_VENV}/bin"
 
@@ -519,14 +641,31 @@ clone_pkg() {
     local src_dir="$2"
     local description="${3:-${yaml_key}}"
 
-    local repo branch is_recursive is_shallow validate_remote clean_generated
+    local repo branch revision commit pinned_ref pinned_field pinned_value is_recursive is_shallow validate_remote clean_generated
 
     repo="$(pkg "${yaml_key}" repo)"
     branch="$(pkg "${yaml_key}" branch)"
+    revision="$(pkg "${yaml_key}" revision)"
+    commit="$(pkg "${yaml_key}" commit)"
     is_recursive="$(pkg "${yaml_key}" recursive)"
     is_shallow="$(pkg "${yaml_key}" shallow)"
     validate_remote="$(pkg "${yaml_key}" validate_remote)"
     clean_generated="$(pkg "${yaml_key}" clean_generated)"
+
+    pinned_ref="${revision:-${commit}}"
+    if [[ -n "${revision}" ]]; then
+        pinned_field="revision"
+    elif [[ -n "${commit}" ]]; then
+        pinned_field="commit"
+    else
+        pinned_field=""
+    fi
+    pinned_value="${pinned_ref:-${branch}}"
+
+    if [[ -n "${pinned_ref}" && "${is_shallow}" == "true" ]]; then
+        warn "${description} requests shallow clone plus pinned ${pinned_field}; cloning full history so ${pinned_field} ${pinned_ref} is available"
+        is_shallow="false"
+    fi
 
     if [[ -d "${src_dir}/.git" ]]; then
         info "${description} already cloned at ${src_dir}"
@@ -542,15 +681,15 @@ clone_pkg() {
             fi
         fi
 
-        # Clean generated files before branch operations (e.g., PyTorch's
+        # Clean generated files before branch/revision operations (e.g., PyTorch's
         # hipify step modifies hundreds of files in-tree)
         if [[ "${clean_generated}" == "true" ]]; then
             local dirty_count
             dirty_count="$(git status --short | wc -l)"
             if [[ "${dirty_count}" -gt 0 ]]; then
                 info "Resetting ${dirty_count} generated files in ${description} tree..."
-                git checkout -- .
-                git submodule foreach --recursive 'git checkout -- . 2>/dev/null || true'
+                git reset --hard HEAD
+                git submodule foreach --recursive 'git reset --hard HEAD 2>/dev/null || true'
             fi
         fi
 
@@ -558,21 +697,31 @@ clone_pkg() {
         # config (e.g. pull.rebase=true, submodule.recurse=true) and can leave
         # dependency submodules in conflicted rebases. We sync submodules
         # explicitly below after the superproject is updated.
-        local current_branch
+        # Fetch and update
+        local current_branch fetch_target
         current_branch="$(git branch --show-current)"
-        local pull_branch="${branch:-${current_branch}}"
-        if [[ -z "${pull_branch}" ]]; then
-            die "Cannot update ${description}: repository is detached HEAD and no branch is configured."
-        fi
-        git -c submodule.recurse=false fetch --no-recurse-submodules origin "${pull_branch}"
+        if [[ -n "${pinned_ref}" ]]; then
+            fetch_target="${pinned_ref}"
+            info "Fetching pinned ${pinned_field} ${pinned_ref}..."
+            git fetch origin "${fetch_target}"
+            info "Checking out pinned ${pinned_field} ${pinned_ref}..."
+            git checkout --detach FETCH_HEAD
+            git reset --hard FETCH_HEAD
+        else
+            fetch_target="${branch:-${current_branch}}"
+            if [[ -z "${fetch_target}" ]]; then
+                die "Cannot update ${description}: repository is detached HEAD and no branch is configured."
+            fi
+            git -c submodule.recurse=false fetch --no-recurse-submodules origin "${fetch_target}"
 
-        # Switch branches if needed
-        if [[ -n "${branch}" && "${current_branch}" != "${branch}" ]]; then
-            info "Switching to ${branch} branch..."
-            git checkout "${branch}"
+            # Switch branches if needed
+            if [[ -n "${branch}" && "${current_branch}" != "${branch}" ]]; then
+                info "Switching to ${branch} branch..."
+                git checkout "${branch}"
+            fi
+            git -c pull.rebase=false -c submodule.recurse=false \
+                pull --ff-only --no-recurse-submodules origin "${fetch_target}"
         fi
-        git -c pull.rebase=false -c submodule.recurse=false \
-            pull --ff-only --no-recurse-submodules origin "${pull_branch}"
 
         # Update submodules if recursive
         if [[ "${is_recursive}" == "true" ]]; then
@@ -582,7 +731,7 @@ clone_pkg() {
         fi
 
         cd "${VLLM_DIR}"
-        success "${description} source updated"
+        success "${description} source updated (${pinned_field:-branch} ${pinned_value})"
         return
     fi
 
@@ -600,7 +749,23 @@ clone_pkg() {
 
     info "Cloning ${description}..."
     git clone "${clone_args[@]}" "${repo}" "${src_dir}"
-    success "${description} cloned to ${src_dir}"
+
+    if [[ -n "${pinned_ref}" ]]; then
+        cd "${src_dir}"
+        info "Fetching pinned ${pinned_field} ${pinned_ref} after clone..."
+        git fetch origin "${pinned_ref}"
+        info "Checking out pinned ${pinned_field} ${pinned_ref}..."
+        git checkout --detach FETCH_HEAD
+        git reset --hard FETCH_HEAD
+        if [[ "${is_recursive}" == "true" ]]; then
+            info "Synchronizing submodules..."
+            git submodule sync --recursive
+            git submodule update --init --recursive --force
+        fi
+        cd "${VLLM_DIR}"
+    fi
+
+    success "${description} cloned to ${src_dir} (${pinned_field:-branch} ${pinned_value})"
 }
 
 # =============================================================================
@@ -713,8 +878,10 @@ apply_patches() {
                 p_rpath="$(ycfg ".packages.${pkg_key}.patches[${i}].rpath")"
                 p_action="$(ycfg ".packages.${pkg_key}.patches[${i}].action")"
 
-                # Expand shell variables
+                # Expand shell variables. Preserve literal ELF loader tokens like
+                # $ORIGIN so set -u does not treat them as shell variables.
                 p_target="$(eval echo "${p_target}")"
+                p_rpath="${p_rpath//\$ORIGIN/\\\$ORIGIN}"
                 p_rpath="$(eval echo "${p_rpath}")"
 
                 info "  [${i}] ${p_description}"
@@ -861,6 +1028,7 @@ validate_pkg() {
 # Generic Build Dependencies Installer
 # =============================================================================
 # Reads build_dependencies from YAML and installs via uv pip install.
+# The caller must activate one of our managed virtual environments first.
 #
 # Usage: install_pkg_deps <pkg_key>
 
@@ -878,6 +1046,9 @@ install_pkg_deps() {
 
     if [[ ${#deps[@]} -gt 0 ]]; then
         info "Installing ${#deps[@]} build dependencies for ${pkg_key}..."
+        if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+            die "install_pkg_deps ${pkg_key} requires an active managed virtual environment"
+        fi
         uv pip install "${deps[@]}"
     fi
 }
@@ -946,10 +1117,10 @@ generate_env_file() {
 # Phase A: Foundation (AOCL-LibM + Python + ROCm SDK)
 # =============================================================================
 
-# Step 5: Build AOCL-Utils (dependency for AOCL-LibM)
+# Step 6: Build AOCL-Utils (dependency for AOCL-LibM)
 # Runs AFTER TheRock so we can use amdclang (AMD's LLVM fork with -famd-opt).
 build_aocl_utils() {
-    log_step 5 "Build AOCL-Utils (CPU feature detection for Zen 5)"
+    log_step 6 "Build AOCL-Utils (CPU feature detection for Zen 5)"
 
     if should_skip_step aocl_utils; then return; fi
 
@@ -963,7 +1134,7 @@ build_aocl_utils() {
     local amdclang="${LOCAL_PREFIX}/lib/llvm/bin/amdclang"
     local amdclangxx="${LOCAL_PREFIX}/lib/llvm/bin/amdclang++"
     if [[ ! -x "${amdclang}" ]]; then
-        die "amdclang not found at ${amdclang} — run TheRock build first (steps 1-4)"
+        die "amdclang not found at ${amdclang} — run TheRock build first (steps 1-5)"
     fi
 
     # Build without LTO: AOCL-LibM links this .a with GNU ld (needed for its
@@ -997,11 +1168,11 @@ build_aocl_utils() {
     success "AOCL-Utils built and installed"
 }
 
-# Step 6: Build AOCL-LibM (AMD-optimized math library)
+# Step 7: Build AOCL-LibM (AMD-optimized math library)
 # Runs AFTER TheRock so we can use amdclang which supports -muse-unaligned-vector-move
 # (AOCL-LibM's build system injects this flag for any clang >= 14.0.6).
 build_aocl_libm() {
-    log_step 6 "Build AOCL-LibM (Zen 5 optimized transcendentals)"
+    log_step 7 "Build AOCL-LibM (Zen 5 optimized transcendentals)"
 
     if should_skip_step aocl_libm; then return; fi
 
@@ -1018,7 +1189,7 @@ build_aocl_libm() {
     local amdclang="${LOCAL_PREFIX}/lib/llvm/bin/amdclang"
     local amdclangxx="${LOCAL_PREFIX}/lib/llvm/bin/amdclang++"
     if [[ ! -x "${amdclang}" ]]; then
-        die "amdclang not found at ${amdclang} — run TheRock build first (steps 1-4)"
+        die "amdclang not found at ${amdclang} — run TheRock build first (steps 1-5)"
     fi
 
     # Apply sed patches from YAML (SConscript fixes for amdclang compatibility)
@@ -1069,9 +1240,9 @@ build_aocl_libm() {
     success "AOCL-LibM built with AVX-512 Zen 5 optimizations"
 }
 
-# Step 7: Build Python from source (using amdclang from TheRock)
+# Step 8: Build Python from source (using amdclang from TheRock)
 build_python() {
-    log_step 7 "Build Python ${CPYTHON_VERSION} from source"
+    log_step 8 "Build Python ${CPYTHON_VERSION} from source"
 
     if should_skip_step cpython; then return; fi
 
@@ -1095,7 +1266,7 @@ build_python() {
     local amdclang="${LOCAL_PREFIX}/lib/llvm/bin/amdclang"
     local amdclangxx="${LOCAL_PREFIX}/lib/llvm/bin/amdclang++"
     if [[ ! -x "${amdclang}" ]]; then
-        die "amdclang not found at ${amdclang} — run TheRock build first (steps 1-4)"
+        die "amdclang not found at ${amdclang} — run TheRock build first (steps 1-5)"
     fi
 
     # Note: we do NOT link CPython against AOCL-LibM (-lalm) directly.
@@ -1152,72 +1323,76 @@ print(f'  LTO: {sysconfig.get_config_var(\"LTOCFLAGS\") or \"none\"}')
     success "Python ${CPYTHON_VERSION} built (PGO + LTO + amdclang)"
 }
 
-# Step 8: Create Virtual Environment (using our custom Python)
-create_venv() {
-    log_step 8 "Create virtual environment"
+create_managed_venv() {
+    local step_num="$1"
+    local step_name="$2"
+    local python_bin="$3"
+    local venv_path="$4"
+    local install_deps="$5"
 
-    # Determine which Python to use: prefer our source-built Python
-    local python_bin="python3"
-    if [[ -x "${LOCAL_PREFIX}/bin/python3" ]]; then
-        python_bin="${LOCAL_PREFIX}/bin/python3"
-        info "Using source-built Python: ${python_bin}"
-    else
-        warn "Source-built Python not found, using system python3"
-    fi
+    log_step "${step_num}" "${step_name}"
 
-    if [[ -d "${VLLM_VENV}" && -f "${VLLM_VENV}/bin/python" ]]; then
-        info "Venv already exists at ${VLLM_VENV}"
+    if [[ -d "${venv_path}" && -f "${venv_path}/bin/python" ]]; then
+        info "Virtual environment already exists at ${venv_path}"
 
-        # Check if the venv uses our custom Python
         local venv_python_real
-        venv_python_real="$(readlink -f "${VLLM_VENV}/bin/python" 2>/dev/null || echo 'unknown')"
-        local custom_python_real
-        custom_python_real="$(readlink -f "${python_bin}" 2>/dev/null || echo 'unknown2')"
-        if [[ "${venv_python_real}" != "${custom_python_real}" && -x "${LOCAL_PREFIX}/bin/python3" ]]; then
-            info "Venv uses different Python (${venv_python_real}), recreating with our build..."
-            rm -r "${VLLM_VENV}"
-        else
-            # shellcheck source=/dev/null
-            source "${VLLM_VENV}/bin/activate"
+        venv_python_real="$(readlink -f "${venv_path}/bin/python" 2>/dev/null || echo 'unknown')"
+        local requested_python_real
+        requested_python_real="$(readlink -f "${python_bin}" 2>/dev/null || echo 'unknown')"
 
-            # Ensure ALL essential build tools are present (may be missing from older venvs)
-            if ! python -c 'import yaml, mako, packaging, CppHeaderParser' 2>/dev/null \
-               || ! command -v ninja &>/dev/null; then
-                info "Installing missing build tools into existing venv..."
-                install_pkg_deps venv
-            fi
-
-            # Ensure uv and yq are in the venv
-            install_tools_to_venv
-
-            success "Venv activated"
-            return
+        if [[ "${venv_python_real}" != "${requested_python_real}" ]]; then
+            info "Environment uses different Python (${venv_python_real}), recreating..."
+            rm -rf "${venv_path}"
         fi
     fi
 
-    info "Creating venv at ${VLLM_VENV} using ${python_bin}..."
-    uv venv --python "${python_bin}" "${VLLM_VENV}"
-
-    # shellcheck source=/dev/null
-    source "${VLLM_VENV}/bin/activate"
-
-    # Ensure AOCL-LibM is on the library path for this venv
-    if [[ -d "${LOCAL_PREFIX}/lib" ]]; then
-        export LD_LIBRARY_PATH="${LOCAL_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    if [[ ! -d "${venv_path}" ]]; then
+        info "Creating virtual environment at ${venv_path} using ${python_bin}..."
+        uv venv --python "${python_bin}" "${venv_path}"
     fi
 
-    # Install essential build tools from YAML manifest
-    install_pkg_deps venv
+    # shellcheck source=/dev/null
+    source "${venv_path}/bin/activate"
 
-    # Install uv and yq into venv for self-contained builds
+    if [[ -d "${LOCAL_PREFIX}/lib" ]]; then
+        export LD_LIBRARY_PATH="${LOCAL_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+        configure_openmp_runtime_env "${LOCAL_PREFIX}"
+    fi
+
+    if [[ "${install_deps}" == "yes" ]]; then
+        install_pkg_deps venv
+    fi
+
     install_tools_to_venv
 
-    success "Venv created and activated (Python $(python --version 2>&1 | awk '{print $2}'))"
+    success "Environment ready at ${venv_path} (Python $(python --version 2>&1 | awk '{print $2}'))"
 }
 
-# Step 2: Configure TheRock
+# Step 2: Create bootstrap virtual environment (using system python3)
+create_bootstrap_venv() {
+    local python_bin
+    python_bin="$(command -v python3)"
+    [[ -n "${python_bin}" ]] || die "python3 not found on PATH"
+
+    create_managed_venv 2 "Create bootstrap virtual environment" "${python_bin}" "${VLLM_VENV}" yes
+}
+
+# Step 9: Create final virtual environment (using our custom Python)
+create_final_venv() {
+    local python_bin="${LOCAL_PREFIX}/bin/python3"
+    if [[ ! -x "${python_bin}" ]]; then
+        warn "Source-built Python not found, falling back to system python3 for final venv"
+        python_bin="$(command -v python3)"
+    else
+        info "Using source-built Python: ${python_bin}"
+    fi
+
+    create_managed_venv 9 "Create final virtual environment" "${python_bin}" "${VLLM_VENV}" yes
+}
+
+# Step 3: Configure TheRock
 configure_therock() {
-    log_step 2 "Configure TheRock (cmake)"
+    log_step 3 "Configure TheRock (cmake)"
 
     cd "${THEROCK_SRC}"
 
@@ -1230,17 +1405,11 @@ configure_therock() {
 
     info "Configuring TheRock for gfx1151..."
 
-    # TheRock's nested cmake sub-builds (LLVM runtimes, hip-clr, amd-mesa)
-    # each run FindPython3 independently and may find a different Python
-    # than the venv. Install required Python packages into whatever python3
-    # cmake would find on the system, in addition to the venv.
-    local sys_python
-    sys_python="$(command -v python3)"
-    if [[ -n "${sys_python}" ]] && ! "${sys_python}" -c 'import yaml, mako, packaging, CppHeaderParser' 2>/dev/null; then
-        info "Installing TheRock Python deps into system python: ${sys_python}"
-        "${sys_python}" -m pip install --break-system-packages \
-            pyyaml mako packaging "CppHeaderParser==2.7.4" 2>/dev/null || true
+    local bootstrap_python="${VLLM_VENV}/bin/python"
+    if [[ ! -x "${bootstrap_python}" ]]; then
+        die "Bootstrap venv missing at ${VLLM_VENV} — run step 2 before configuring TheRock further"
     fi
+
 
     # TheRock requires GCC — rocprofiler-systems has an explicit GNU
     # compiler check that blocks Clang. Unset all amdclang-specific flags;
@@ -1249,17 +1418,19 @@ configure_therock() {
           CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS
 
     # TheRock has deeply nested cmake sub-builds (LLVM -> runtimes) that
-    # each run FindPython3 independently. TheRock now runs BEFORE our venv
-    # exists, so we point at the system python3 (which we installed build
-    # deps into above).
-    # Python3_ROOT_DIR is the cmake hint that propagates through sub-builds.
+    # each run FindPython3 independently. We create a bootstrap venv before
+    # this phase so those sub-builds see a consistent interpreter with the
+    # required Python packages already installed. Python3_ROOT_DIR is the
+    # cmake hint that propagates through sub-builds.
     cmake -B build -GNinja . \
         -DTHEROCK_AMDGPU_FAMILIES=gfx1151 \
         -DCMAKE_C_COMPILER=gcc \
         -DCMAKE_CXX_COMPILER=g++ \
         -DCMAKE_INSTALL_PREFIX="${LOCAL_PREFIX}" \
-        -DPython3_EXECUTABLE="${sys_python}" \
+        -DPython3_EXECUTABLE="${bootstrap_python}" \
+        -DPython3_ROOT_DIR="${VLLM_VENV}" \
         -DTHEROCK_BUILD_TESTING=OFF \
+        -DTHEROCK_ENABLE_ROCGDB=OFF \
         -DTHEROCK_ENABLE_PROFILER=OFF \
         -DTHEROCK_FLAG_INCLUDE_PROFILER=OFF
         # Profiler disabled: rocprofiler-sdk's vendored yaml-cpp and elfio
@@ -1274,9 +1445,9 @@ configure_therock() {
     success "TheRock configured"
 }
 
-# Step 3: Build TheRock
+# Step 4: Build TheRock
 build_therock() {
-    log_step 3 "Build TheRock (this will take several hours)"
+    log_step 4 "Build TheRock (this will take several hours)"
 
     cd "${THEROCK_SRC}"
 
@@ -1324,9 +1495,9 @@ build_therock() {
     success "TheRock built and installed (${therock_version})"
 }
 
-# Step 4: Validate ROCm
+# Step 5: Validate ROCm
 validate_rocm() {
-    log_step 4 "Validate ROCm installation"
+    log_step 5 "Validate ROCm installation"
 
 
     # Update environment to use locally-built ROCm.
@@ -1334,6 +1505,7 @@ validate_rocm() {
     export ROCM_PATH="${LOCAL_PREFIX}"
     export LD_LIBRARY_PATH="${ROCM_PATH}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     export PATH="${ROCM_PATH}/lib/llvm/bin:${ROCM_PATH}/bin:${PATH}"
+    configure_openmp_runtime_env "${ROCM_PATH}"
 
     # Create clang/clang++ symlinks to amdclang/amdclang++ so that build
     # systems looking for "clang" on PATH find the AMD-optimized variant.
@@ -1404,9 +1576,9 @@ validate_rocm() {
 # Phase B: ML Framework (PyTorch, ROCm fork)
 # =============================================================================
 
-# Step 10: Build PyTorch
+# Step 11: Build PyTorch
 build_pytorch() {
-    log_step 10 "Build PyTorch with ROCm support"
+    log_step 11 "Build PyTorch with ROCm support"
 
     cd "${PYTORCH_SRC}"
 
@@ -1448,6 +1620,10 @@ build_pytorch() {
     # patchelf patches are skipped here (applied to unpacked wheel below).
     apply_patches pytorch "${PYTORCH_SRC}"
 
+    if grep -q -- '-fclang-abi-compat=17' "${PYTORCH_SRC}/cmake/Dependencies.cmake"; then
+        die "PyTorch ABI patch failed: cmake/Dependencies.cmake still contains -fclang-abi-compat=17"
+    fi
+
     # HIPGraph.hip: file_rewrite (too complex for YAML, handled inline)
     local _hipgraph="${PYTORCH_SRC}/aten/src/ATen/hip/HIPGraph.hip"
     if [[ -f "${_hipgraph}" ]] && grep -q 'cudaGraphConditionalHandle' "${_hipgraph}"; then
@@ -1470,6 +1646,10 @@ HIPEOF
 
     # Step 1: Build the wheel. pip wheel runs cmake (incremental if build/
     # exists) and packages everything into a .whl file.
+    if [[ -d "${PYTORCH_SRC}/build" ]]; then
+        info "Removing stale PyTorch build tree to avoid reusing objects with old HIP ABI flags..."
+        rm -rf "${PYTORCH_SRC}/build"
+    fi
     info "Building PyTorch wheel (this takes 1-2 hours on first build)..."
     mkdir -p "${WHEELS_DIR}"
     pip wheel . \
@@ -1483,11 +1663,15 @@ HIPEOF
     # during packaging, so patching the source tree beforehand doesn't work —
     # the wheel gets fresh unpatched copies. Instead, we unpack the .whl,
     # patch the .so files, and repack. Two fixes:
-    #   1. RPATH: add /opt/src/vllm/local/lib so libalm.so, librocm_smi64.so,
-    #      and other ROCm libs resolve without LD_LIBRARY_PATH at runtime
+    #   1. RPATH: add /opt/src/vllm/local/lib and the LLVM runtime dir so
+    #      ROCm libs, libomp.so, and sibling torch/*.so files resolve without
+    #      LD_LIBRARY_PATH at runtime
     #   2. NEEDED: add librocm_smi64.so to libtorch_hip.so (PyTorch's build
     #      system omits it from the link line despite using rsmi_* symbols —
     #      upstream bug, causes "undefined symbol: rsmi_init" at runtime)
+    #   3. NEEDED: add libomp.so to libtorch_cpu.so when the amdclang-built
+    #      wheel leaves __kmpc_* symbols unresolved without an explicit OpenMP
+    #      dependency, causing "undefined symbol: __kmpc_fork_call" on import
     local _torch_wheel
     _torch_wheel="$(newest_wheel "${WHEELS_DIR}"/torch-*.whl)"
     if [[ -z "${_torch_wheel}" ]]; then
@@ -1503,29 +1687,34 @@ HIPEOF
     # Fix RPATHs: cmake bakes the build tree path into RUNPATH (e.g.
     # /opt/src/vllm/pytorch/build/lib). This causes the dynamic linker to
     # load unpatched .so files from the build tree instead of the wheel's
-    # copies. Clean all RPATHs to only contain the ROCm prefix and $ORIGIN.
+    # copies. Clean all RPATHs to only contain the ROCm prefix, the LLVM
+    # runtime dir (libomp.so), and $ORIGIN.
+    local _torch_lib_rpath="${LOCAL_PREFIX}/lib:${LOCAL_PREFIX}/lib/llvm/lib:\$ORIGIN"
+    local _torch_ext_rpath="${LOCAL_PREFIX}/lib:${LOCAL_PREFIX}/lib/llvm/lib:\$ORIGIN/lib"
     for _so in torch/lib/lib*.so; do
         [[ -f "${_so}" ]] || continue
-        local _rpath
-        _rpath="$(readelf -d "${_so}" 2>/dev/null | grep 'RUNPATH' || true)"
-        if echo "${_rpath}" | grep -q 'pytorch/build'; then
-            patchelf --set-rpath "${LOCAL_PREFIX}/lib:\$ORIGIN" "${_so}" 2>/dev/null || true
-        elif readelf -d "${_so}" 2>/dev/null | grep -q 'libalm.so\|libamdhip64\|librocm_smi'; then
-            patchelf --add-rpath "${LOCAL_PREFIX}/lib" "${_so}" 2>/dev/null || true
-        fi
+        patchelf --set-rpath "${_torch_lib_rpath}" "${_so}" 2>/dev/null || true
     done
-    # Also fix the _C extension module if it has build tree RPATH
+    # Also fix the _C extension module so it finds wheel-local torch/lib/*.so
+    # plus the ROCm and LLVM/OpenMP runtimes from the install prefix.
     for _so in torch/_C*.so; do
         [[ -f "${_so}" ]] || continue
-        if readelf -d "${_so}" 2>/dev/null | grep -q 'pytorch/build'; then
-            patchelf --set-rpath "${LOCAL_PREFIX}/lib:\$ORIGIN/lib" "${_so}" 2>/dev/null || true
-        fi
+        patchelf --set-rpath "${_torch_ext_rpath}" "${_so}" 2>/dev/null || true
     done
 
     # Add librocm_smi64.so to libtorch_hip.so NEEDED list
     if [[ -f "torch/lib/libtorch_hip.so" ]] && ! readelf -d "torch/lib/libtorch_hip.so" 2>/dev/null | grep -q 'librocm_smi64'; then
         info "  Adding librocm_smi64.so to libtorch_hip.so NEEDED"
         patchelf --add-needed librocm_smi64.so "torch/lib/libtorch_hip.so"
+    fi
+
+    # Add libomp.so to libtorch_cpu.so when PyTorch's amdclang/OpenMP link
+    # leaves __kmpc_* symbols unresolved without an explicit NEEDED entry.
+    if [[ -f "torch/lib/libtorch_cpu.so" ]] \
+        && readelf --dyn-syms "torch/lib/libtorch_cpu.so" 2>/dev/null | grep -q '__kmpc_fork_call' \
+        && ! readelf -d "torch/lib/libtorch_cpu.so" 2>/dev/null | grep -q 'libomp'; then
+        info "  Adding libomp.so to libtorch_cpu.so NEEDED"
+        patchelf --add-needed libomp.so "torch/lib/libtorch_cpu.so"
     fi
 
     # Repack the wheel using Python's zipfile (zip may not be installed)
@@ -1565,11 +1754,14 @@ with zipfile.ZipFile('${_torch_wheel}', 'w', zipfile.ZIP_DEFLATED) as zf:
     success "PyTorch built and installed (wheel: $(basename "${_torch_wheel}"))"
 }
 
-# Step 11: Validate PyTorch
+# Step 12: Validate PyTorch
 validate_pytorch() {
-    log_step 11 "Validate PyTorch GPU access"
+    log_step 12 "Validate PyTorch GPU access"
 
-    python -c "
+    local _torch_validate_log
+    _torch_validate_log="$(mktemp)"
+    local _validate_cmd
+    _validate_cmd="$(cat <<'PY'
 import torch
 print(f'  PyTorch version: {torch.__version__}')
 print(f'  CUDA available: {torch.cuda.is_available()}')
@@ -1579,14 +1771,34 @@ if torch.cuda.is_available():
     print(f'  Device count: {torch.cuda.device_count()}')
 else:
     raise RuntimeError('PyTorch cannot see GPU — build may have failed')
-" || die "PyTorch GPU validation failed"
+PY
+)"
+
+    if ! python -c "${_validate_cmd}" >"${_torch_validate_log}" 2>&1; then
+        cat "${_torch_validate_log}" >&2
+        diagnose_pytorch_import_failure "${_torch_validate_log}"
+        if is_known_pytorch_rocm_import_failure "${_torch_validate_log}" && retry_pytorch_wheel_install; then
+            if ! python -c "${_validate_cmd}" >"${_torch_validate_log}" 2>&1; then
+                cat "${_torch_validate_log}" >&2
+                diagnose_pytorch_import_failure "${_torch_validate_log}"
+                rm -f "${_torch_validate_log}"
+                die "PyTorch GPU validation failed after reinstall retry"
+            fi
+        else
+            rm -f "${_torch_validate_log}"
+            die "PyTorch GPU validation failed"
+        fi
+    fi
+
+    cat "${_torch_validate_log}"
+    rm -f "${_torch_validate_log}"
 
     success "PyTorch GPU access verified"
 }
 
-# Step 13: Build TorchVision
+# Step 14: Build TorchVision
 build_torchvision() {
-    log_step 13 "Build TorchVision (against source-built PyTorch)"
+    log_step 14 "Build TorchVision (against source-built PyTorch)"
 
     cd "${TORCHVISION_SRC}"
 
@@ -1628,9 +1840,9 @@ build_torchvision() {
 # Phase D: Kernel Compilers (Triton + AOTriton)
 # =============================================================================
 
-# Step 15: Build Triton
+# Step 16: Build Triton
 build_triton() {
-    log_step 15 "Build Triton with ROCm backend"
+    log_step 16 "Build Triton with ROCm backend"
 
     cd "${TRITON_SRC}"
 
@@ -1648,7 +1860,7 @@ build_triton() {
 
     # Validate ROCm toolchain is available.
     if [[ -z "${ROCM_PATH:-}" || ! -d "${ROCM_PATH}/lib/llvm" ]]; then
-        die "ROCM_PATH is not set or ${ROCM_PATH:-<unset>}/lib/llvm does not exist. Run TheRock build first (steps 5-8)."
+        die "ROCM_PATH is not set or ${ROCM_PATH:-<unset>}/lib/llvm does not exist. Run TheRock build first (steps 1-5)."
     fi
 
     # Ensure vllm-env.sh flags are active
@@ -1703,9 +1915,9 @@ build_triton() {
     success "Triton built with ROCm backend (wheel: $(basename "${_triton_wheel}"))"
 }
 
-# Step 16: Validate Triton
+# Step 17: Validate Triton
 validate_triton() {
-    log_step 16 "Validate Triton"
+    log_step 17 "Validate Triton"
 
     python -c "
 import triton
@@ -1730,9 +1942,9 @@ except ImportError:
     success "Triton validated"
 }
 
-# Step 18: Build AOTriton
+# Step 19: Build AOTriton
 build_aotriton() {
-    log_step 18 "Build AOTriton (pre-compiled attention kernels for gfx1151)"
+    log_step 19 "Build AOTriton (pre-compiled attention kernels for gfx1151)"
 
     cd "${AOTRITON_SRC}"
 
@@ -1781,9 +1993,9 @@ build_aotriton() {
 # Phase D: Inference Engine (vLLM)
 # =============================================================================
 
-# Step 20: Patch amdsmi Import Order
+# Step 21: Patch amdsmi Import Order
 patch_amdsmi_import() {
-    log_step 20 "Patch amdsmi import order in vLLM"
+    log_step 21 "Patch amdsmi import order in vLLM"
 
     local init_file="${VLLM_SRC}/vllm/__init__.py"
 
@@ -1847,7 +2059,7 @@ with open('${init_file}', 'w') as f:
     success "amdsmi import patch applied"
 }
 
-# Step 20b: Patch vLLM for gfx1151 (RDNA 3.5) AITER support
+# Step 21b: Patch vLLM for gfx1151 (RDNA 3.5) AITER support
 #
 # vLLM upstream gates AITER backend selection on gfx9 architectures only.
 # The AMD fork's AITER has full gfx1151 support (chip_info.py maps gfx1151
@@ -1861,10 +2073,10 @@ with open('${init_file}', 'w') as f:
 #   3. rocm.py:get_vit_attn_backend() — ViT attention: KEEP gfx9-only (CK fmha_fwd
 #      rejects ViT dimensions on gfx1151; RDNA 3.5 falls through to TRITON_ATTN)
 patch_vllm_gfx1151() {
-    log_step 20 "Patch vLLM for gfx1151 AITER support"
+    log_step 21 "Patch vLLM for gfx1151 AITER support"
 
     # Apply all sed-type patches from YAML (AITER gfx1x imports, FA backend,
-    # ViT revert, rms_norm guard, fusion skip_duplicates, sampler bypass,
+    # ViT revert, rms_norm guard, fusion skip_duplicates,
     # FLA chunk_delta_h fixes, qwen3_next warmup restriction)
     apply_patches vllm "${VLLM_SRC}"
 
@@ -2215,9 +2427,9 @@ with open('${_rocm_aiter_unified}', 'w') as f:
     success "vLLM gfx1151 AITER patches applied"
 }
 
-# Step 21: Install Build Dependencies
+# Step 22: Install Build Dependencies
 install_build_deps() {
-    log_step 21 "Install build dependencies"
+    log_step 22 "Install build dependencies"
 
     # Install build dependencies from YAML manifest
     install_pkg_deps vllm
@@ -2225,9 +2437,9 @@ install_build_deps() {
     success "Build dependencies installed"
 }
 
-# Step 22: Run use_existing_torch.py
+# Step 23: Run use_existing_torch.py
 run_use_existing_torch() {
-    log_step 22 "Run use_existing_torch.py"
+    log_step 23 "Run use_existing_torch.py"
 
     cd "${VLLM_SRC}"
 
@@ -2244,9 +2456,9 @@ run_use_existing_torch() {
     success "use_existing_torch.py completed"
 }
 
-# Step 23: Install ROCm Requirements
+# Step 24: Install ROCm Requirements
 install_rocm_requirements() {
-    log_step 23 "Install ROCm requirements"
+    log_step 24 "Install ROCm requirements"
 
     cd "${VLLM_SRC}"
 
@@ -2321,9 +2533,9 @@ CONSTRAINTS_EOF
     success "ROCm requirements installed"
 }
 
-# Step 24: Build vLLM
+# Step 25: Build vLLM
 build_vllm() {
-    log_step 24 "Build vLLM"
+    log_step 25 "Build vLLM"
 
     cd "${VLLM_SRC}"
 
@@ -2385,18 +2597,241 @@ build_vllm() {
     if [[ -n "${_vllm_wheel}" ]]; then
         info "Installing vLLM wheel into build venv..."
         uv pip install --force-reinstall --no-deps "${_vllm_wheel}"
+        patch_installed_vllm_runtime
     fi
 
     cd "${VLLM_DIR}"
+}
+
+# Ensure the installed vLLM runtime contains skip_duplicates=True in
+# rocm_aiter_fusion.py. This guards against cases where the source tree was
+# patched but an older/unpatched wheel ended up active in site-packages.
+patch_installed_vllm_runtime() {
+    info "Verifying installed vLLM runtime patch state (rocm_aiter_fusion.py)..."
+
+    local fusion_file
+    fusion_file="$(python - <<'PY'
+import importlib.util
+spec = importlib.util.find_spec("vllm.compilation.passes.fusion.rocm_aiter_fusion")
+print(spec.origin if spec and spec.origin else "")
+PY
+)"
+
+    if [[ -z "${fusion_file}" || ! -f "${fusion_file}" ]]; then
+        die "Could not locate installed rocm_aiter_fusion.py in active venv"
+    fi
+
+    if grep -q "skip_duplicates=True" "${fusion_file}"; then
+        success "Installed runtime already has skip_duplicates=True (${fusion_file})"
+        return
+    fi
+
+    warn "Installed runtime missing skip_duplicates=True; patching ${fusion_file}"
+    cp -f "${fusion_file}" "${fusion_file}.bak"
+    sed -i '/pm\.register_replacement(/,/)/{ s/pm_pass,$/pm_pass, skip_duplicates=True,/; s/pm_pass$/pm_pass, skip_duplicates=True/ }' "${fusion_file}"
+
+    if ! grep -q "skip_duplicates=True" "${fusion_file}"; then
+        die "Failed to patch installed rocm_aiter_fusion.py (backup at ${fusion_file}.bak)"
+    fi
+
+    success "Installed runtime patched with skip_duplicates=True (${fusion_file})"
+
+    # -------------------------------------------------------------------------
+    # Installed rocm.py hybrid-attention guard (critical for gfx1151 stability)
+    # -------------------------------------------------------------------------
+    local rocm_py
+    rocm_py="$(python - <<'PY'
+import importlib.util
+spec = importlib.util.find_spec("vllm.platforms.rocm")
+print(spec.origin if spec and spec.origin else "")
+PY
+)"
+    if [[ -z "${rocm_py}" || ! -f "${rocm_py}" ]]; then
+        die "Could not locate installed vllm/platforms/rocm.py in active venv"
+    fi
+
+    if ! grep -q "_is_hybrid" "${rocm_py}"; then
+        warn "Installed rocm.py missing hybrid-attention guard; patching ${rocm_py}"
+        python3 - <<PY
+from pathlib import Path
+
+path = Path("${rocm_py}")
+content = path.read_text()
+old = '''    backends = []
+
+    # Priority 1: Check for AITER Unified Attention (must check before MHA)
+    if envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION:
+        backends.append(AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
+
+    # Priority 2: Check for AITER MHA (Flash Attention)
+    if envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA:
+        backends.append(AttentionBackendEnum.ROCM_AITER_FA)
+
+    # Priority 3: Check for ROCM_ATTN (prefill-decode split)
+    from vllm.config import get_current_vllm_config_or_none
+
+    vllm_config = get_current_vllm_config_or_none()'''
+
+new = '''    backends = []
+
+    from vllm.config import get_current_vllm_config_or_none
+
+    vllm_config = get_current_vllm_config_or_none()
+
+    # Hybrid models (e.g. Qwen3.5 GDN) compute non-power-of-2 block sizes
+    # from mamba state alignment. AITER unified attention and AITER FA both
+    # use TILE_SIZE = block_size in Triton kernels, which requires a power
+    # of 2 and small enough to fit in LDS. Skip AITER attention backends
+    # for hybrid models and fall through to TRITON_ATTN.
+    _is_hybrid = (
+        vllm_config is not None
+        and vllm_config.model_config is not None
+        and vllm_config.model_config.is_hybrid
+    )
+
+    # Priority 1: Check for AITER Unified Attention (must check before MHA)
+    if envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION and not _is_hybrid:
+        backends.append(AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
+
+    # Priority 2: Check for AITER MHA (Flash Attention)
+    if envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MHA and not _is_hybrid:
+        backends.append(AttentionBackendEnum.ROCM_AITER_FA)
+
+    # Priority 3: Check for ROCM_ATTN (prefill-decode split)'''
+
+if old not in content:
+    raise SystemExit("rocm.py patch pattern not found")
+content = content.replace(old, new, 1)
+path.write_text(content)
+PY
+    fi
+
+    if ! grep -q "_is_hybrid" "${rocm_py}"; then
+        die "Installed rocm.py still missing hybrid-attention guard (${rocm_py})"
+    fi
+    success "Installed runtime includes hybrid-attention guard (${rocm_py})"
+
+    # -------------------------------------------------------------------------
+    # Installed _aiter_ops.py RMSNorm gfx1x dispatch guard
+    # -------------------------------------------------------------------------
+    local aiter_ops_py
+    aiter_ops_py="$(python - <<'PY'
+import importlib.util
+spec = importlib.util.find_spec("vllm._aiter_ops")
+print(spec.origin if spec and spec.origin else "")
+PY
+)"
+    if [[ -z "${aiter_ops_py}" || ! -f "${aiter_ops_py}" ]]; then
+        die "Could not locate installed vllm/_aiter_ops.py in active venv"
+    fi
+
+    if ! grep -q "aiter.ops.triton.normalization.rmsnorm" "${aiter_ops_py}"; then
+        warn "Installed _aiter_ops.py missing gfx1x RMSNorm dispatch guard; patching ${aiter_ops_py}"
+        python3 - <<PY
+from pathlib import Path
+
+path = Path("${aiter_ops_py}")
+content = path.read_text()
+
+old1 = '''    import aiter as rocm_aiter
+
+    assert quant_dtype in [torch.int8, FP8_DTYPE]
+
+    y_scale = torch.empty(x.shape[0], 1, dtype=torch.float32, device=x.device)
+    out = torch.empty(x.shape, dtype=quant_dtype, device=x.device)
+    residual_out = torch.empty_like(x)
+
+    rocm_aiter.rmsnorm2d_fwd_with_add_dynamicquant(
+        out,
+        x,
+        residual,
+        residual_out,
+        y_scale,
+        weight,
+        epsilon,
+        use_model_sensitive_rmsnorm=0,
+    )
+
+    return out, residual_out, y_scale'''
+
+new1 = '''    from vllm.platforms.rocm import on_gfx1x
+
+    assert quant_dtype in [torch.int8, FP8_DTYPE]
+
+    y_scale = torch.empty(x.shape[0], 1, dtype=torch.float32, device=x.device)
+    out = torch.empty(x.shape, dtype=quant_dtype, device=x.device)
+    residual_out = torch.empty_like(x)
+
+    if on_gfx1x():
+        from aiter.ops.triton.normalization.rmsnorm import (
+            rmsnorm2d_fwd_with_add_dynamicquant,
+        )
+        rmsnorm2d_fwd_with_add_dynamicquant(
+            out, x, residual, residual_out, y_scale, weight, epsilon,
+        )
+    else:
+        import aiter as rocm_aiter
+        rocm_aiter.rmsnorm2d_fwd_with_add_dynamicquant(
+            out, x, residual, residual_out, y_scale, weight, epsilon,
+            use_model_sensitive_rmsnorm=0,
+        )
+
+    return out, residual_out, y_scale'''
+
+old2 = '''    import aiter as rocm_aiter
+
+    assert quant_dtype in [torch.int8, FP8_DTYPE]
+
+    y_scale = torch.empty(x.shape[0], 1, dtype=torch.float32, device=x.device)
+    out = torch.empty(x.shape, dtype=quant_dtype, device=x.device)
+
+    rocm_aiter.rmsnorm2d_fwd_with_dynamicquant(
+        out, x, y_scale, weight, epsilon, use_model_sensitive_rmsnorm=0
+    )
+
+    return out, y_scale'''
+
+new2 = '''    from vllm.platforms.rocm import on_gfx1x
+
+    assert quant_dtype in [torch.int8, FP8_DTYPE]
+
+    y_scale = torch.empty(x.shape[0], 1, dtype=torch.float32, device=x.device)
+    out = torch.empty(x.shape, dtype=quant_dtype, device=x.device)
+
+    if on_gfx1x():
+        from aiter.ops.triton.normalization.rmsnorm import (
+            rmsnorm2d_fwd_with_dynamicquant,
+        )
+        rmsnorm2d_fwd_with_dynamicquant(out, x, y_scale, weight, epsilon)
+    else:
+        import aiter as rocm_aiter
+        rocm_aiter.rmsnorm2d_fwd_with_dynamicquant(
+            out, x, y_scale, weight, epsilon, use_model_sensitive_rmsnorm=0
+        )
+
+    return out, y_scale'''
+
+if old1 not in content or old2 not in content:
+    raise SystemExit("_aiter_ops.py patch pattern not found")
+
+content = content.replace(old1, new1, 1).replace(old2, new2, 1)
+path.write_text(content)
+PY
+    fi
+
+    if ! grep -q "aiter.ops.triton.normalization.rmsnorm" "${aiter_ops_py}"; then
+        die "Installed _aiter_ops.py still missing gfx1x RMSNorm dispatch guard (${aiter_ops_py})"
+    fi
+    success "Installed runtime includes gfx1x RMSNorm dispatch guard (${aiter_ops_py})"
 }
 
 # =============================================================================
 # Phase F: Attention (Flash Attention + AITER)
 # =============================================================================
 
-# Step 25: Reinstall amdsmi
+# Step 26: Reinstall amdsmi
 reinstall_amdsmi() {
-    log_step 25 "Reinstall amdsmi from ROCm"
+    log_step 26 "Reinstall amdsmi from ROCm"
 
     if [[ -z "${ROCM_PATH:-}" ]]; then
         die "ROCM_PATH not set."
@@ -2423,9 +2858,9 @@ reinstall_amdsmi() {
     success "amdsmi reinstalled from ROCm"
 }
 
-# Step 27: Patch Flash Attention amdsmi Import
+# Step 28: Patch Flash Attention amdsmi Import
 patch_flash_amdsmi() {
-    log_step 27 "Patch Flash Attention amdsmi import"
+    log_step 28 "Patch Flash Attention amdsmi import"
 
     local init_file="${FLASH_ATTN_SRC}/flash_attn/__init__.py"
 
@@ -2456,9 +2891,9 @@ patch_flash_amdsmi() {
     success "Flash Attention amdsmi patch applied"
 }
 
-# Step 28: Build Flash Attention
+# Step 29: Build Flash Attention
 build_flash_attention() {
-    log_step 28 "Build Flash Attention"
+    log_step 29 "Build Flash Attention"
 
     cd "${FLASH_ATTN_SRC}"
 
@@ -2539,7 +2974,7 @@ with open('${_fa_setup}', 'w') as f:
     success "Flash Attention built"
 }
 
-# Step 28b: Rebuild AITER from source
+# Step 29b: Rebuild AITER from source
 # The aiter package includes pre-compiled .cu files (aiter_meta/csrc/cpp_itfs/)
 # and a bundled CK (Composable Kernel) submodule. At runtime, AITER's MHA
 # kernels JIT-compile using CK tile headers from CK_DIR. If the installed
@@ -2552,7 +2987,7 @@ with open('${_fa_setup}', 'w') as f:
 # matching CK submodule, ensuring the compiled .cu interfaces and CK headers
 # are from the same commit.
 rebuild_aiter() {
-    log_step 28 "Rebuild AITER from source (CK-aligned)"
+    log_step 29 "Rebuild AITER from source (CK-aligned)"
 
     local aiter_src="${VLLM_DIR}/pytorch/third_party/aiter"
     if [[ ! -d "${aiter_src}" || ! -f "${aiter_src}/setup.py" ]]; then
@@ -2633,7 +3068,7 @@ rebuild_aiter() {
     success "AITER rebuilt from source (CK commit ${ck_commit})"
 }
 
-# Step 28b: Patch AITER headers for gfx1151 (RDNA 3.5) compatibility
+# Step 29b: Patch AITER headers for gfx1151 (RDNA 3.5) compatibility
 #
 # AITER's HIP kernel sources contain CDNA-only (gfx9) assembly instructions
 # that fail JIT compilation on RDNA 3/3.5 (gfx11xx). Two headers need
@@ -2655,7 +3090,7 @@ rebuild_aiter() {
 # Patches target installed site-packages headers (not source tree) because
 # AITER's JIT reads from the venv, not the build tree.
 patch_aiter_gfx1151() {
-    log_step 28 "Patch AITER headers for gfx1151 RDNA 3.5"
+    log_step 29 "Patch AITER headers for gfx1151 RDNA 3.5"
 
     local site_packages
     site_packages="$(python -c 'import site; print(site.getsitepackages()[0])')"
@@ -3272,9 +3707,9 @@ HIPREDUCE_EOF
 # Phase G: Validation
 # =============================================================================
 
-# Step 29: Smoke Test
+# Step 30: Smoke Test
 smoke_test() {
-    log_step 29 "Smoke test"
+    log_step 30 "Smoke test"
 
     info "Verifying full inference stack..."
 
@@ -3305,26 +3740,40 @@ else:
     print(f'  Python: WARNING — may not be from source build')
 "
 
-    # Check PyTorch was built from source (not pip wheel)
+    # Check PyTorch provenance.
+    # Note: source-built wheels are installed into site-packages, so __file__
+    # will not point into /opt/src/vllm/pytorch even for source builds.
     python -c "
 import torch
 loc = torch.__file__
+ver = getattr(torch, '__version__', '<unknown>')
 print(f'  PyTorch location: {loc}')
-if '/opt/src/vllm/pytorch/' in loc:
+if '/opt/src/vllm/.venv/' in loc and ('+git' in ver or '.dev' in ver):
+    print(f'  PyTorch version: {ver}')
+    print('  PyTorch: BUILT FROM SOURCE (installed source wheel)')
+elif '/opt/src/vllm/pytorch/' in loc:
     print('  PyTorch: BUILT FROM SOURCE (ROCm fork)')
 else:
-    print(f'  PyTorch: WARNING — may not be from source build')
+    print(f'  PyTorch version: {ver}')
+    print(f'  PyTorch: WARNING — provenance unclear (installed path does not prove source build)')
 "
 
-    # Check Triton
+    # Check Triton provenance.
+    # Same caveat as PyTorch: source-built Triton is still installed into
+    # site-packages.
     python -c "
 import triton
 loc = triton.__file__
+ver = getattr(triton, '__version__', '<unknown>')
 print(f'  Triton location: {loc}')
-if '/opt/src/vllm/triton/' in loc:
+if '/opt/src/vllm/.venv/' in loc and ('+git' in ver or '.dev' in ver):
+    print(f'  Triton version: {ver}')
+    print('  Triton: BUILT FROM SOURCE (installed source wheel)')
+elif '/opt/src/vllm/triton/' in loc:
     print('  Triton: BUILT FROM SOURCE (ROCm fork)')
 else:
-    print(f'  Triton: WARNING — may not be from source build')
+    print(f'  Triton version: {ver}')
+    print(f'  Triton: WARNING — provenance unclear (installed path does not prove source build)')
 "
 
     # Check Flash Attention
@@ -3377,7 +3826,7 @@ except ImportError as e:
     info "  All compiled from source with Clang $(${CC} --version | head -1 | grep -oP '\d+\.\d+\.\d+' | head -1)"
 }
 
-# Step 29b: Pre-warm AITER JIT modules
+# Step 30b: Pre-warm AITER JIT modules
 # Compiles all buildable AITER HIP C++ modules ahead of time so that the first
 # vLLM inference request doesn't stall for minutes while modules JIT-compile.
 # In a CK-free build (no Composable Kernel sources), 56 of 72 modules are
@@ -3391,7 +3840,7 @@ except ImportError as e:
 # These failures are non-fatal — the modules target gfx9xx hardware features
 # that RDNA 3.5 doesn't have and would never be called at runtime.
 warmup_aiter_jit() {
-    log_step 29 "Pre-warm AITER JIT modules"
+    log_step 30 "Pre-warm AITER JIT modules"
 
     # Skip if AITER is not enabled
     local aiter_status
@@ -3562,7 +4011,7 @@ if failed > 0:
     success "AITER JIT pre-warm: ${built_count} modules compiled in ${jit_dir}"
 }
 
-# Step 36: Backend Smoke Test
+# Step 37: Backend Smoke Test
 # Downloads a tiny model (SmolLM2-135M-Instruct, ~270 MB FP16 / ~70 MB Q4 GGUF)
 # and runs actual inference through every installed backend:
 #   1. vLLM      – offline LLM inference + TunableOp CSV warmup as side effect
@@ -3575,7 +4024,7 @@ if failed > 0:
 # Individual backend failures are non-fatal — a summary table is printed at
 # the end showing PASS / FAIL / SKIP for each backend.
 backend_smoke_test() {
-    log_step 36 "Backend smoke test (all inference backends)"
+    log_step 37 "Backend smoke test (all inference backends)"
 
     # ── Load .env overrides (e.g. SMOKE_SKIP_VLLM=1) ──────────────────
     # Supported skip variables:
@@ -3630,6 +4079,39 @@ print(path)
         fi
     fi
 
+    # ── Device pinning (multi-GPU hosts) ────────────────────────────────
+    # Honor explicit override without probing torch.cuda here. Probing CUDA in
+    # the parent process can initialize runtime state before vLLM spawns worker
+    # processes, which breaks multiprocessing startup.
+    local smoke_rocm_gpu_index="${SMOKE_ROCM_GPU_INDEX:-${SMOKE_GPU_INDEX:-}}"
+    local smoke_vk_gpu_index="${SMOKE_VK_GPU_INDEX:-${SMOKE_GPU_INDEX:-}}"
+
+    # ROCm and Vulkan device indices can differ on mixed-GPU hosts.
+    if [[ -n "${smoke_rocm_gpu_index}" ]]; then
+        local _rocm_visible_ok
+        _rocm_visible_ok="$(
+            HIP_VISIBLE_DEVICES="${smoke_rocm_gpu_index}" \
+                python -c "import torch; print(1 if torch.cuda.is_available() and torch.cuda.device_count() > 0 else 0)" 2>/dev/null
+        )"
+        if [[ "${_rocm_visible_ok}" == "1" ]]; then
+            export HIP_VISIBLE_DEVICES="${smoke_rocm_gpu_index}"
+            info "Pinned ROCm smoke backends to GPU index ${smoke_rocm_gpu_index}"
+        else
+            warn "ROCm index ${smoke_rocm_gpu_index} is not visible; falling back to ROCm index 0"
+            export HIP_VISIBLE_DEVICES=0
+            info "Pinned ROCm smoke backends to GPU index 0"
+        fi
+    else
+        warn "SMOKE_ROCM_GPU_INDEX/SMOKE_GPU_INDEX not set; using runtime default ROCm device selection"
+    fi
+
+    if [[ -n "${smoke_vk_gpu_index}" ]]; then
+        export GGML_VK_VISIBLE_DEVICES="${smoke_vk_gpu_index}"
+        info "Pinned Vulkan smoke backends to GPU index ${smoke_vk_gpu_index}"
+    else
+        warn "SMOKE_VK_GPU_INDEX/SMOKE_GPU_INDEX not set; using runtime default Vulkan device selection"
+    fi
+
     # ── Backend 1/5: vLLM (offline inference + TunableOp warmup) ─────────
     section "Backend 1/5: vLLM (offline inference + TunableOp warmup)"
 
@@ -3638,11 +4120,48 @@ print(path)
         info "vLLM: SKIP (SMOKE_SKIP_VLLM set)"
     else
 
-    local tunableop_csv="${VLLM_DIR}/tunableop_results_gfx11510.csv"
-    info "TunableOp CSV: ${tunableop_csv}"
+    local vllm_runtime_versions
+    vllm_runtime_versions="$(
+        python -c "from importlib.metadata import version; print(f\"torch={version('torch')} triton={version('triton')} vllm={version('vllm')}\")" 2>/dev/null
+    )"
+    if [[ -n "${vllm_runtime_versions}" ]]; then
+        info "vLLM runtime versions: ${vllm_runtime_versions}"
+    else
+        warn "vLLM runtime versions: unavailable (import failed)"
+    fi
 
-    if python -c "
+    local tunableop_stack_tag
+    tunableop_stack_tag="$(
+        python -c "import torch, triton; print(f\"torch{torch.__version__.split('+')[0]}_triton{triton.__version__}\")" 2>/dev/null \
+        | tr -c '[:alnum:]_.-' '_'
+    )"
+    if [[ -z "${tunableop_stack_tag}" ]]; then
+        tunableop_stack_tag="unknown_stack"
+    fi
+    local tunableop_csv="${VLLM_DIR}/tunableop_results_gfx11510_${tunableop_stack_tag}.csv"
+    info "TunableOp CSV: ${tunableop_csv}"
+    # Keep smoke runs deterministic: stale/partially-written tuning entries from
+    # prior crashes can poison first inference and obscure root-cause debugging.
+    if [[ -f "${tunableop_csv}" ]]; then
+        info "Resetting TunableOp CSV for clean smoke run"
+        rm -f "${tunableop_csv}"
+    fi
+
+    local _vllm_output
+    local _vllm_log="${VLLM_DIR}/backend-smoke-vllm.log"
+    if _vllm_output="$(env -u VLLM_DIR -u VLLM_VENV -u VLLM_SRC -u VLLM_LOG python -c "
 import os
+import multiprocessing as mp
+
+# Set multiprocessing mode before importing vLLM/torch internals. This avoids
+# ROCm/CUDA lazy-init conflicts in worker bootstrap paths that still assume
+# default fork semantics.
+try:
+    mp.set_start_method('spawn', force=True)
+except RuntimeError:
+    pass
+os.environ['VLLM_WORKER_MULTIPROC_METHOD'] = 'spawn'
+
 os.environ['PYTORCH_TUNABLEOP_ENABLED'] = '1'
 os.environ['PYTORCH_TUNABLEOP_FILENAME'] = '${tunableop_csv}'
 os.environ['PYTORCH_TUNABLEOP_TUNING'] = '1'
@@ -3652,6 +4171,9 @@ from vllm import LLM, SamplingParams
 print('Loading model: ${hf_model}')
 llm = LLM(
     model='${hf_model}',
+    # RDNA 3.5 runtime is noticeably more stable in fp16 during first-load
+    # smoke tests; bf16 defaults can trigger intermittent GPU page faults.
+    dtype='float16',
     max_model_len=512,
     gpu_memory_utilization=0.3,
     enforce_eager=True,  # No graph capture during tuning
@@ -3688,15 +4210,35 @@ for out in outputs:
 # the engine is broken.
 assert total_output_tokens > 0, 'vLLM produced zero output tokens across all prompts'
 print('PASS')
-"; then
+" 2>&1)" && echo "${_vllm_output}" | grep -q '^PASS$' && ! echo "${_vllm_output}" | grep -q 'Traceback (most recent call last):'; then
+        echo "${_vllm_output}"
         results[vllm]="PASS"
         success "vLLM: PASS"
+        printf '%s\n' "${_vllm_output}" > "${_vllm_log}"
         if [[ -f "${tunableop_csv}" ]]; then
             local csv_lines
             csv_lines="$(wc -l < "${tunableop_csv}")"
             info "TunableOp CSV populated: ${csv_lines} kernel entries"
         fi
     else
+        if [[ -n "${_vllm_output:-}" ]]; then
+            printf '%s\n' "${_vllm_output}" > "${_vllm_log}"
+            warn "vLLM smoke test full log: ${_vllm_log}"
+            warn "vLLM smoke test tail (last 120 lines):"
+            tail -n 120 "${_vllm_log}" || true
+            if grep -q "No module named 'triton.language.target_info'" "${_vllm_log}"; then
+                warn "Detected Triton target_info import errors."
+                warn "ROCm Triton intentionally does not ship CUDA-only target_info/gluon APIs."
+                warn "On this stack, treat these lines as compatibility noise unless followed by a hard runtime fault."
+            fi
+            if grep -qE 'Memory access fault by GPU|HSA_STATUS|hipError' "${_vllm_log}"; then
+                warn "Detected a hard GPU runtime fault during model bring-up (likely the true failure cause)."
+            fi
+            if grep -q 'Engine core initialization failed' "${_vllm_log}"; then
+                warn "Detected vLLM core startup failure. Showing likely root-cause lines:"
+                grep -nE 'Engine core initialization failed|Failed core proc|Traceback|ERROR|RuntimeError|ValueError|ImportError|ModuleNotFoundError|hipError|HSA_STATUS|Memory access fault by GPU' "${_vllm_log}" | tail -n 80 || true
+            fi
+        fi
         results[vllm]="FAIL"
         warn "vLLM: FAIL"
     fi
@@ -3716,14 +4258,15 @@ print('PASS')
         results[llamacpp_rocm]="SKIP"
         warn "llama.cpp ROCm: SKIP (llama-cli not found at ${LLAMACPP_INSTALL_DIR}/llama-cli)"
     else
+        local smoke_llamacpp_timeout="${SMOKE_LLAMACPP_TIMEOUT:-180}"
         info "Running: ${LLAMACPP_INSTALL_DIR}/llama-cli -m ${gguf_file}"
         # Warmup: first run loads model weights and initializes GPU buffers
         info "  Warmup pass..."
-        timeout 120 "${LLAMACPP_INSTALL_DIR}/llama-cli" \
+        printf '/exit\n' | timeout -k 15 120 "${LLAMACPP_INSTALL_DIR}/llama-cli" \
             -m "${gguf_path}" -p "warmup" -n 1 --no-display-prompt --single-turn --simple-io -ngl 99 \
-            </dev/null >/dev/null 2>&1 || true
-        local _rocm_output
-        if _rocm_output="$(timeout 60 "${LLAMACPP_INSTALL_DIR}/llama-cli" \
+            >/dev/null 2>&1 || true
+        local _rocm_output _rocm_text _rocm_status
+        _rocm_output="$(printf '/exit\n' | timeout -k 15 "${smoke_llamacpp_timeout}" "${LLAMACPP_INSTALL_DIR}/llama-cli" \
             -m "${gguf_path}" \
             -p "${test_prompt}" \
             -n "${max_tokens}" \
@@ -3731,28 +4274,43 @@ print('PASS')
             --single-turn \
             --simple-io \
             -ngl 99 \
-            </dev/null \
-            2>/dev/null)"; then
+            2>&1)"
+        _rocm_status=$?
+        if [[ "${_rocm_status}" -eq 0 ]]; then
             # In PTY-backed runs llama-cli may still emit banner and prompt text; isolate
             # the assistant reply between the prompt line and trailing perf footer.
-            _rocm_output="$(printf '%s\n' "${_rocm_output}" | tr -d '\r\010' | awk '
+            _rocm_text="$(printf '%s\n' "${_rocm_output}" | tr -d '\r\010' | awk '
 BEGIN { capture=0 }
 /^> / { capture=1; next }
 /^\[ Prompt:/ { capture=0 }
 /^Exiting\.\.\.$/ { capture=0 }
+/^common_/ { capture=0 }
+/^[[:space:]]*\| memory breakdown/ { capture=0 }
 capture { print }
 ' | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | head -c 200)"
-            if [[ -n "${_rocm_output}" ]]; then
+            if [[ -z "${_rocm_text}" ]]; then
+                _rocm_text="$(printf '%s\n' "${_rocm_output}" | sed -n 's/^| *//p' | tr -d '\n' | head -c 200)"
+            fi
+            if [[ -z "${_rocm_text}" ]]; then
+                _rocm_text="$(printf '%s\n' "${_rocm_output}" | sed 's/\x1b\[[0-9;]*m//g' | awk 'NF {last=$0} END {print last}' | head -c 200)"
+            fi
+            if [[ -n "${_rocm_text}" ]]; then
                 results[llamacpp_rocm]="PASS"
                 success "llama.cpp ROCm: PASS"
-                info "  Output: ${_rocm_output:0:80}"
+                info "  Output: ${_rocm_text:0:80}"
             else
                 results[llamacpp_rocm]="FAIL"
                 warn "llama.cpp ROCm: FAIL (empty output)"
+                echo "${_rocm_output}" | tail -n 40
             fi
+        elif [[ "${_rocm_status}" -eq 124 ]]; then
+            results[llamacpp_rocm]="FAIL"
+            warn "llama.cpp ROCm: FAIL (timeout after ${smoke_llamacpp_timeout}s; set SMOKE_LLAMACPP_TIMEOUT to increase)"
+            [[ -n "${_rocm_output:-}" ]] && echo "${_rocm_output}" | tail -n 40
         else
             results[llamacpp_rocm]="FAIL"
-            warn "llama.cpp ROCm: FAIL (inference error)"
+            warn "llama.cpp ROCm: FAIL (inference error, exit ${_rocm_status})"
+            [[ -n "${_rocm_output:-}" ]] && echo "${_rocm_output}" | tail -n 40
         fi
     fi
 
@@ -3769,14 +4327,15 @@ capture { print }
         results[llamacpp_vulkan]="SKIP"
         warn "llama.cpp Vulkan: SKIP (llama-cli not found at ${LLAMACPP_VULKAN_DIR}/llama-cli)"
     else
+        local smoke_llamacpp_timeout="${SMOKE_LLAMACPP_TIMEOUT:-180}"
         info "Running: ${LLAMACPP_VULKAN_DIR}/llama-cli -m ${gguf_file}"
         # Warmup: first run loads model weights and initializes Vulkan resources
         info "  Warmup pass..."
-        timeout 120 "${LLAMACPP_VULKAN_DIR}/llama-cli" \
+        printf '/exit\n' | timeout -k 15 120 "${LLAMACPP_VULKAN_DIR}/llama-cli" \
             -m "${gguf_path}" -p "warmup" -n 1 --no-display-prompt --single-turn --simple-io -ngl 99 \
-            </dev/null >/dev/null 2>&1 || true
-        local _vulkan_output
-        if _vulkan_output="$(timeout 60 "${LLAMACPP_VULKAN_DIR}/llama-cli" \
+            >/dev/null 2>&1 || true
+        local _vulkan_output _vulkan_text _vulkan_status
+        _vulkan_output="$(printf '/exit\n' | timeout -k 15 "${smoke_llamacpp_timeout}" "${LLAMACPP_VULKAN_DIR}/llama-cli" \
             -m "${gguf_path}" \
             -p "${test_prompt}" \
             -n "${max_tokens}" \
@@ -3784,26 +4343,41 @@ capture { print }
             --single-turn \
             --simple-io \
             -ngl 99 \
-            </dev/null \
-            2>/dev/null)"; then
-            _vulkan_output="$(printf '%s\n' "${_vulkan_output}" | tr -d '\r\010' | awk '
+            2>&1)"
+        _vulkan_status=$?
+        if [[ "${_vulkan_status}" -eq 0 ]]; then
+            _vulkan_text="$(printf '%s\n' "${_vulkan_output}" | tr -d '\r\010' | awk '
 BEGIN { capture=0 }
 /^> / { capture=1; next }
 /^\[ Prompt:/ { capture=0 }
 /^Exiting\.\.\.$/ { capture=0 }
+/^common_/ { capture=0 }
+/^[[:space:]]*\| memory breakdown/ { capture=0 }
 capture { print }
 ' | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | head -c 200)"
-            if [[ -n "${_vulkan_output}" ]]; then
+            if [[ -z "${_vulkan_text}" ]]; then
+                _vulkan_text="$(printf '%s\n' "${_vulkan_output}" | sed -n 's/^| *//p' | tr -d '\n' | head -c 200)"
+            fi
+            if [[ -z "${_vulkan_text}" ]]; then
+                _vulkan_text="$(printf '%s\n' "${_vulkan_output}" | sed 's/\x1b\[[0-9;]*m//g' | awk 'NF {last=$0} END {print last}' | head -c 200)"
+            fi
+            if [[ -n "${_vulkan_text}" ]]; then
                 results[llamacpp_vulkan]="PASS"
                 success "llama.cpp Vulkan: PASS"
-                info "  Output: ${_vulkan_output:0:80}"
+                info "  Output: ${_vulkan_text:0:80}"
             else
                 results[llamacpp_vulkan]="FAIL"
                 warn "llama.cpp Vulkan: FAIL (empty output)"
+                echo "${_vulkan_output}" | tail -n 40
             fi
+        elif [[ "${_vulkan_status}" -eq 124 ]]; then
+            results[llamacpp_vulkan]="FAIL"
+            warn "llama.cpp Vulkan: FAIL (timeout after ${smoke_llamacpp_timeout}s; set SMOKE_LLAMACPP_TIMEOUT to increase)"
+            [[ -n "${_vulkan_output:-}" ]] && echo "${_vulkan_output}" | tail -n 40
         else
             results[llamacpp_vulkan]="FAIL"
-            warn "llama.cpp Vulkan: FAIL (inference error)"
+            warn "llama.cpp Vulkan: FAIL (inference error, exit ${_vulkan_status})"
+            [[ -n "${_vulkan_output:-}" ]] && echo "${_vulkan_output}" | tail -n 40
         fi
     fi
 
@@ -3813,13 +4387,31 @@ capture { print }
     if [[ -n "${SMOKE_SKIP_LEMONADE:-}" ]]; then
         results[lemonade]="SKIP"
         info "Lemonade: SKIP (SMOKE_SKIP_LEMONADE set)"
-    elif ! python -c "import lemonade" 2>/dev/null; then
+    elif ! python -c "
+import importlib.util
+assert importlib.util.find_spec('lemonade') or importlib.util.find_spec('lemonade_sdk')
+" 2>/dev/null; then
         results[lemonade]="SKIP"
         warn "Lemonade: SKIP (SDK not importable)"
     else
         info "Running Lemonade SDK inference..."
         if python -c "
-from lemonade.api import from_pretrained
+from_pretrained = None
+for _mod_name, _attr in (
+    ('lemonade.api', 'from_pretrained'),
+    ('lemonade', 'from_pretrained'),
+    ('lemonade_sdk.api', 'from_pretrained'),
+    ('lemonade_sdk', 'from_pretrained'),
+):
+    try:
+        _mod = __import__(_mod_name, fromlist=[_attr])
+        from_pretrained = getattr(_mod, _attr)
+        break
+    except (ModuleNotFoundError, AttributeError):
+        continue
+
+if from_pretrained is None:
+    raise ModuleNotFoundError('Could not import from_pretrained from lemonade/lemonade_sdk')
 
 print('Loading model via Lemonade (hf-dgpu): ${hf_model}')
 model, tokenizer = from_pretrained(
@@ -3944,18 +4536,26 @@ print('PASS')
 #   Rust packages:  RUSTFLAGS="-C target-cpu=znver5" enables AVX-512, VAES
 #   C/C++ packages: CFLAGS from vllm-env.sh (-O3 -march=native -flto=thin ...)
 
-# Step 30: Build Rust optimized wheels (orjson, cryptography)
+# Step 31: Build Rust optimized wheels (orjson, cryptography)
 build_rust_wheels() {
-    log_step 30 "Build Rust optimized wheels (orjson, cryptography)"
+    log_step 31 "Build Rust optimized wheels (orjson, cryptography)"
 
     mkdir -p "${WHEELS_DIR}"
 
-    # Verify Rust toolchain
+    # Verify Rust toolchain.
+    # In non-interactive shells, rustup's PATH hook may not be loaded even when
+    # Rust is already installed under ~/.cargo/bin.
+    if ! command -v rustc &>/dev/null || ! command -v cargo &>/dev/null; then
+        if [[ -f "${HOME}/.cargo/env" ]]; then
+            # shellcheck disable=SC1090
+            source "${HOME}/.cargo/env"
+        fi
+    fi
     if ! command -v rustc &>/dev/null; then
-        die "Rust toolchain not found. Install with: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+        die "Rust toolchain not found (rustc missing from PATH). Install with: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
     fi
     if ! command -v cargo &>/dev/null; then
-        die "cargo not found. Install with rustup."
+        die "cargo not found (cargo missing from PATH). Install with rustup."
     fi
 
     local rust_ver
@@ -4036,9 +4636,9 @@ build_rust_wheels() {
     success "Rust optimized wheels complete"
 }
 
-# Step 31: Build C/C++ optimized wheels
+# Step 32: Build C/C++ optimized wheels
 build_native_wheels() {
-    log_step 31 "Build C/C++ optimized wheels (numpy, sentencepiece, zstandard, asyncpg, duckdb)"
+    log_step 32 "Build C/C++ optimized wheels (numpy, sentencepiece, zstandard, asyncpg, duckdb)"
 
     mkdir -p "${WHEELS_DIR}"
 
@@ -4047,8 +4647,14 @@ build_native_wheels() {
     # isolation, the cmake Python module isn't available, so sentencepiece and
     # pyarrow both fail when their build scripts invoke cmake. Replace the
     # broken wrapper with a symlink to the real system cmake.
-    local _real_cmake
-    _real_cmake="$(command -v cmake 2>/dev/null || true)"
+    local _real_cmake _cmake_candidate
+    _real_cmake=""
+    while IFS= read -r _cmake_candidate; do
+        [[ -x "${_cmake_candidate}" ]] || continue
+        [[ "${_cmake_candidate}" == "${VLLM_DIR}/.venv/bin/cmake" ]] && continue
+        _real_cmake="${_cmake_candidate}"
+        break
+    done < <(which -a cmake 2>/dev/null || true)
     if [[ -f "${VLLM_DIR}/.venv/bin/cmake" ]] && head -1 "${VLLM_DIR}/.venv/bin/cmake" | grep -q python; then
         if [[ -n "${_real_cmake}" && "${_real_cmake}" != "${VLLM_DIR}/.venv/bin/cmake" ]]; then
             info "Replacing broken Python cmake wrapper with symlink to ${_real_cmake}"
@@ -4130,9 +4736,9 @@ build_native_wheels() {
     success "C/C++ optimized wheels complete"
 }
 
-# Step 32: Export existing source builds as distributable wheels
+# Step 33: Export existing source builds as distributable wheels
 export_source_wheels() {
-    log_step 32 "Export source-built packages as wheels (torch, triton, torchvision, amd-aiter, amdsmi)"
+    log_step 33 "Export source-built packages as wheels (torch, triton, torchvision, amd-aiter, amdsmi)"
 
     mkdir -p "${WHEELS_DIR}"
 
@@ -4235,11 +4841,11 @@ export_source_wheels() {
     # Verify all required wheels exist (built in earlier steps)
     local _vllm_wheel _fa_wheel
     _vllm_wheel="$(newest_wheel "${WHEELS_DIR}"/vllm-*.whl)"
-    [[ -n "${_vllm_wheel}" ]] || die "vLLM wheel missing from ${WHEELS_DIR} — run step 24 first"
+    [[ -n "${_vllm_wheel}" ]] || die "vLLM wheel missing from ${WHEELS_DIR} — run step 25 first"
     success "vllm wheel exists: $(basename "${_vllm_wheel}")"
 
     _fa_wheel="$(newest_wheel "${WHEELS_DIR}"/flash_attn-*.whl)"
-    [[ -n "${_fa_wheel}" ]] || die "flash_attn wheel missing from ${WHEELS_DIR} — run step 28 first"
+    [[ -n "${_fa_wheel}" ]] || die "flash_attn wheel missing from ${WHEELS_DIR} — run step 29 first"
     success "flash_attn wheel exists: $(basename "${_fa_wheel}")"
 
     # Summary — verify all 14 packages are present
@@ -4268,7 +4874,7 @@ export_source_wheels() {
 # expects them, with a .env file injecting gfx1151 runtime optimizations.
 
 clone_and_build_lemonade() {
-    log_step 33 "Clone Lemonade + build llama.cpp with hipBLAS for gfx1151"
+    log_step 34 "Clone Lemonade + build llama.cpp with hipBLAS for gfx1151"
 
     # Clone both repos using generic clone_pkg (reads flags from YAML)
     clone_pkg lemonade "${LEMONADE_SRC}" "Lemonade SDK"
@@ -4452,17 +5058,26 @@ clone_and_build_lemonade() {
 }
 
 install_lemonade_sdk() {
-    log_step 34 "Install Lemonade SDK"
+    log_step 35 "Install Lemonade SDK"
 
     # The Lemonade project split in v10: the git repo (v10.0.0) is a C++ server,
     # while the Python SDK is published separately as lemonade-sdk on PyPI (v9.1.4).
     # The SDK handles llama-server process management, model downloads, .env loading,
     # and hardware detection. We install from PyPI.
 
-    # Check if already installed
-    if python -c "import lemonade" 2>/dev/null; then
+    # Check if already installed. Import path can vary by SDK release.
+    if python -c "
+import importlib.util
+assert importlib.util.find_spec('lemonade') or importlib.util.find_spec('lemonade_sdk')
+" 2>/dev/null; then
         info "Lemonade SDK already installed in venv"
-        python -c "import lemonade; print(f'  Version: {lemonade.__version__}')" 2>/dev/null || true
+        python -c '
+try:
+    import lemonade as _lem
+except ModuleNotFoundError:
+    import lemonade_sdk as _lem
+print("  Version: {}".format(getattr(_lem, "__version__", "unknown")))
+' 2>/dev/null || true
     else
         info "Installing lemonade-sdk from PyPI..."
         pip install lemonade-sdk 2>&1
@@ -4511,7 +5126,7 @@ print(f'  llama-server (vulkan): {path}')
 }
 
 validate_lemonade() {
-    log_step 35 "Validate Lemonade installation"
+    log_step 36 "Validate Lemonade installation"
 
     # Check llama-server binary
     if [[ ! -x "${LLAMACPP_INSTALL_DIR}/llama-server" ]]; then
@@ -4561,7 +5176,10 @@ validate_lemonade() {
     fi
 
     # Check Lemonade SDK import
-    if python -c "import lemonade" 2>/dev/null; then
+    if python -c "
+import importlib.util
+assert importlib.util.find_spec('lemonade') or importlib.util.find_spec('lemonade_sdk')
+" 2>/dev/null; then
         success "Lemonade SDK importable in venv"
     else
         warn "Lemonade SDK not importable — run step 34"
@@ -4660,6 +5278,7 @@ main() {
         export ROCM_PATH="${LOCAL_PREFIX}"
         export LD_LIBRARY_PATH="${LOCAL_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
         export PATH="${LOCAL_PREFIX}/lib/llvm/bin:${LOCAL_PREFIX}/bin:${PATH}"
+        configure_openmp_runtime_env "${LOCAL_PREFIX}"
         if [[ -d "${LOCAL_PREFIX}/llvm/amdgcn/bitcode" ]]; then
             export DEVICE_LIB_PATH="${LOCAL_PREFIX}/llvm/amdgcn/bitcode"
             export HIP_DEVICE_LIB_PATH="${LOCAL_PREFIX}/llvm/amdgcn/bitcode"

--- a/strix-halo/vllm-env.sh
+++ b/strix-halo/vllm-env.sh
@@ -186,6 +186,17 @@ fi
 if [[ -n "${ROCM_PATH:-}" && -d "${ROCM_PATH}" ]]; then
     export LD_LIBRARY_PATH="${ROCM_PATH}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     export PATH="${ROCM_PATH}/lib/llvm/bin:${ROCM_PATH}/bin:${PATH}"
+    for _omp_candidate in \
+        "${ROCM_PATH}/lib/llvm/lib/libomp.so" \
+        "${ROCM_PATH}/lib/llvm/lib/libiomp5.so" \
+        "${ROCM_PATH}/lib/libomp.so" \
+        "${ROCM_PATH}/lib/libiomp5.so"; do
+        [[ -f "${_omp_candidate}" ]] || continue
+        case ":${LD_PRELOAD:-}:" in
+            *:"${_omp_candidate}":*) break ;;
+            *) export LD_PRELOAD="${_omp_candidate}${LD_PRELOAD:+:${LD_PRELOAD}}"; break ;;
+        esac
+    done
 
     # Device bitcode may be under llvm/ or directly under amdgcn/
     if [[ -d "${ROCM_PATH}/llvm/amdgcn/bitcode" ]]; then

--- a/strix-halo/vllm-packages.yaml
+++ b/strix-halo/vllm-packages.yaml
@@ -89,7 +89,7 @@ platform:
 
 build:
   vllm_dir: "/opt/src/vllm"
-  total_steps: 36
+  total_steps: 37
   cpython_version: "3.13.12"
   disk_required_gb: 100
   clang_min_version: 21
@@ -187,59 +187,60 @@ steps:
   #   clone:<pkg_key> entries are dispatched to clone_pkg() automatically.
   #   All other entries are shell function names called directly.
   1:  { clone: therock, desc: "TheRock ROCm source (with submodules)" }
-  2:  configure_therock
-  3:  build_therock
-  4:  validate_rocm
+  2:  create_bootstrap_venv
+  3:  configure_therock
+  4:  build_therock
+  5:  validate_rocm
 
   # Phase B: CPU Libraries + Python
-  5:  build_aocl_utils
-  6:  build_aocl_libm
-  7:  build_python
-  8:  create_venv
+  6:  build_aocl_utils
+  7:  build_aocl_libm
+  8:  build_python
+  9:  create_final_venv
 
   # Phase C: ML Framework (PyTorch + TorchVision)
-  9:  { clone: pytorch, desc: "PyTorch source (ROCm fork)" }
-  10: build_pytorch
-  11: validate_pytorch
-  12: { clone: torchvision, desc: "TorchVision source" }
-  13: build_torchvision
+  10: { clone: pytorch, desc: "PyTorch source (ROCm fork)" }
+  11: build_pytorch
+  12: validate_pytorch
+  13: { clone: torchvision, desc: "TorchVision source" }
+  14: build_torchvision
 
   # Phase D: Kernel Compilers (Triton + AOTriton)
-  14: { clone: triton, desc: "Triton source (ROCm fork)" }
-  15: build_triton
-  16: validate_triton
-  17: { clone: aotriton, desc: "AOTriton (ahead-of-time Triton kernels)" }
-  18: build_aotriton
+  15: { clone: triton, desc: "Triton source (ROCm fork)" }
+  16: build_triton
+  17: validate_triton
+  18: { clone: aotriton, desc: "AOTriton (ahead-of-time Triton kernels)" }
+  19: build_aotriton
 
   # Phase E: Inference Engine (vLLM)
-  19: { clone: vllm, desc: "vLLM source" }
-  20: [patch_amdsmi_import, patch_vllm_gfx1151]
-  21: install_build_deps
-  22: run_use_existing_torch
-  23: install_rocm_requirements
-  24: build_vllm
+  20: { clone: vllm, desc: "vLLM source" }
+  21: [patch_amdsmi_import, patch_vllm_gfx1151]
+  22: install_build_deps
+  23: run_use_existing_torch
+  24: install_rocm_requirements
+  25: build_vllm
 
   # Phase F: Attention (Flash Attention + AITER)
-  25: reinstall_amdsmi
-  26: { clone: flash_attention, desc: "Flash Attention (main_perf branch)" }
-  27: patch_flash_amdsmi
-  28: [build_flash_attention, rebuild_aiter, patch_aiter_gfx1151]
+  26: reinstall_amdsmi
+  27: { clone: flash_attention, desc: "Flash Attention (main_perf branch)" }
+  28: patch_flash_amdsmi
+  29: [build_flash_attention, rebuild_aiter, patch_aiter_gfx1151]
 
   # Phase G: Validation + Warmup
-  29: [smoke_test, warmup_aiter_jit]
+  30: [smoke_test, warmup_aiter_jit]
 
   # Phase H: Optimized Wheels
-  30: build_rust_wheels
-  31: build_native_wheels
-  32: export_source_wheels
+  31: build_rust_wheels
+  32: build_native_wheels
+  33: export_source_wheels
 
   # Phase I: Lemonade Inference Server
-  33: clone_and_build_lemonade
-  34: install_lemonade_sdk
-  35: validate_lemonade
+  34: clone_and_build_lemonade
+  35: install_lemonade_sdk
+  36: validate_lemonade
 
   # Phase J: Backend Smoke Test (all inference backends)
-  36: backend_smoke_test
+  37: backend_smoke_test
 
 # =============================================================================
 # Packages: per-component metadata (repos, patches, build notes)
@@ -257,7 +258,7 @@ packages:
     src_dir: "therock"
     method: cmake
     phase: A
-    steps: [1, 2, 3, 4]
+    steps: [1, 3, 4, 5]
     depends_on: []
     compiler: gcc
     skip_marker: "lib/libamdhip64.so"
@@ -306,7 +307,7 @@ packages:
 
       # 3. Add <cstdint> to yaml-cpp (transitive include removed)
       - type: sed
-        file: "external/rocprofiler-sdk/external-rocprofiler-sdk/external/yaml-cpp/src/emitterutils.cpp"
+        file: "rocm-systems/projects/rocprofiler-sdk/external/yaml-cpp/src/emitterutils.cpp"
         marker: "<cstdint>"
         marker_absent: true
         sed_command: "/#include <algorithm>/a #include <cstdint>"
@@ -317,7 +318,7 @@ packages:
 
       # 4. Add <cstdint> to elfio (same transitive include issue)
       - type: sed
-        file: "external/rocprofiler-sdk/external-rocprofiler-sdk/external/elfio/elfio/elf_types.hpp"
+        file: "rocm-systems/projects/rocprofiler-sdk/external/elfio/elfio/elf_types.hpp"
         marker: "<cstdint>"
         marker_absent: true
         sed_command: "/#define ELFTYPES_H/a #include <cstdint>"
@@ -346,6 +347,217 @@ packages:
           cmake which unconditionally copies it into the wheel. TheRock
           builds it but doesn't install it when THEROCK_BUILD_TESTING=OFF.
 
+      # 7. Skip CUDA-only libhipcxx atomic_codegen tests when nvcc/cuobjdump are absent
+      - type: sed
+        file: "math-libs/libhipcxx/test/atomic_codegen/CMakeLists.txt"
+        marker: "if (filecheck)"
+        sed_command: '/if (filecheck)/,/endif()/c if (filecheck AND LIBCUDACXX_ENABLE_CUDA)\n  message(\"-- ${filecheck} found... building atomic codegen tests\")\nelse()\n  return()\nendif()'
+        description: >
+          Skip libhipcxx atomic_codegen tests unless the CUDA backend is
+          actually enabled. Upstream gates this directory only on FileCheck,
+          so HIP-only ROCm builds still enter the CUDA-specific test setup and
+          then fail on missing NVIDIA tools like cuobjdump.
+
+
+      # 8. ROCR-Runtime OpenCL blit kernels need an explicit ROCm device-lib path
+      - type: sed
+        file: "rocm-systems/projects/rocr-runtime/runtime/hsa-runtime/image/blit_src/CMakeLists.txt"
+        marker: "--rocm-device-lib-path"
+        marker_absent: true
+        sed_command: '/function(gen_kernel_bc TARGET_ID INPUT_FILE OUTPUT_FILE)/a \
+  set(_rocm_device_lib_path "")\n  foreach(_candidate ${CMAKE_PREFIX_PATH}/llvm/amdgcn/bitcode ${CMAKE_PREFIX_PATH}/amdgcn/bitcode)\n    if(EXISTS "${_candidate}")\n      set(_rocm_device_lib_path "${_candidate}")\n      break()\n    endif()\n  endforeach()\n  if(_rocm_device_lib_path)\n    set(_rocm_device_lib_flag "--rocm-device-lib-path=${_rocm_device_lib_path}")\n  endif()'
+        description: >
+          Teach ROCR-Runtime's OpenCL blit kernel generator where ROCm device
+          bitcode lives during TheRock builds. Its custom clang -x cl command
+          does not inherit a usable default ROCm install root while bootstrapping,
+          so current clang releases abort unless --rocm-device-lib-path points
+          at the amdgcn/bitcode directory under CMAKE_PREFIX_PATH.
+      - type: sed
+        file: "rocm-systems/projects/rocr-runtime/runtime/hsa-runtime/image/blit_src/CMakeLists.txt"
+        marker: "-mcode-object-version=4 -o"
+        sed_command: 's|-mcode-object-version=4 |-mcode-object-version=4 ${_rocm_device_lib_flag} |'
+        description: >
+          Append the detected ROCm device-lib path to ROCR-Runtime's clang -x cl
+          blit compile command so the generated ocl_blit_object_* bitcode builds
+          against the just-built device libraries instead of failing discovery.
+
+      # 8. Skip roctx64 patch hooks when profiler stack is disabled
+      - type: sed
+        file: "comm-libs/pre_hook_rccl.cmake"
+        marker: "if(NOT WIN32)"
+        sed_command: "s|if(NOT WIN32)|if(NOT WIN32 AND THEROCK_ENABLE_PROFILER)|"
+        description: >
+          Skip RCCL's legacy roctx64 link patch when TheRock profiler support
+          is disabled. The top-level build config sets THEROCK_ENABLE_PROFILER=OFF,
+          so roctracer/roctx64 are intentionally unavailable and should not be
+          hard-required during RCCL configure.
+
+      - type: sed
+        file: "math-libs/BLAS/pre_hook_rocBLAS.cmake"
+        marker: "if(NOT WIN32)"
+        sed_command: "s|if(NOT WIN32)|if(NOT WIN32 AND THEROCK_ENABLE_PROFILER)|"
+        description: >
+          Skip rocBLAS' legacy roctx64 link patch when the profiler stack is
+          disabled, matching the top-level THEROCK_ENABLE_PROFILER=OFF build.
+
+      - type: sed
+        file: "math-libs/BLAS/pre_hook_rocSPARSE.cmake"
+        marker: "if(NOT WIN32)"
+        sed_command: "s|if(NOT WIN32)|if(NOT WIN32 AND THEROCK_ENABLE_PROFILER)|"
+        description: >
+          Skip rocSPARSE's legacy roctx64 link patch when the profiler stack is
+          disabled, avoiding the same missing-roctx64 configure failure later in
+          the math library build.
+
+      # 9. Disable RCCL ROCTX tracing when profiler stack is disabled
+      - type: sed
+        file: "comm-libs/CMakeLists.txt"
+        marker: "-DROCTX=OFF"
+        marker_absent: true
+        sed_command: '/-DENABLE_MSCCL_KERNEL=OFF/a\      -DROCTX=OFF'
+        description: >
+          Disable RCCL's optional ROCTX tracing integration. Upstream RCCL
+          enables ROCTX by default and later calls find_library(roctx64),
+          which fails under TheRock builds configured with
+          THEROCK_ENABLE_PROFILER=OFF because roctracer/roctx64 are not built.
+
+      # 9b. Restore RCCL tuner macro definitions before rccl_common.h uses them
+      - type: sed
+        file: "rocm-systems/projects/rccl/src/include/rccl_common.h"
+        marker: '#include "plugin/nccl_tuner.h"'
+        marker_absent: true
+        sed_command: |-
+          /#include "nccl.h"/a\
+          #include "plugin\/nccl_tuner.h"
+        description: >
+          Ensure RCCL's internal tuner macros are visible before rccl_common.h
+          references NCCL_NUM_ALGORITHMS and NCCL_NUM_PROTOCOLS. The current
+          RCCL snapshot defines those macros in plugin/nccl_tuner.h, so newer
+          rccl_common.h revisions fail to compile if that header is not pulled
+          in explicitly.
+
+      # 9c. Make RCCL's NVTX header honor the stub-only build configuration
+      - type: sed
+        file: "rocm-systems/projects/rccl/src/include/nvtx.h"
+        marker: '#ifdef NVTX_NO_IMPL'
+        marker_absent: true
+        sed_command: |-
+          /^#define NCCL_NVTX_H_$/a\
+          #ifdef NVTX_NO_IMPL\
+          #include "nvtx_stub.h"\
+          #else
+        description: >
+          Make RCCL's nvtx.h defer to nvtx_stub.h when TheRock passes
+          -DNVTX_NO_IMPL. Some sources include nvtx.h directly instead of going
+          through core.h, so without this guard the real NVTX declarations and
+          stub declarations are both compiled, causing nccl_domain and macro
+          redefinition errors.
+      - type: sed
+        file: "rocm-systems/projects/rccl/src/include/nvtx.h"
+        marker: '#endif // NVTX_NO_IMPL'
+        marker_absent: true
+        sed_command: |-
+          $i\
+          #endif // NVTX_NO_IMPL
+        description: >
+          Close the NVTX_NO_IMPL guard added to RCCL's nvtx.h so profiler-
+          disabled builds consistently use the stub header path.
+      - type: sed
+        file: "rocm-systems/projects/rccl/src/include/nvtx_stub.h"
+        marker: '#define NCCL_NVTX3_FUNC_RANGE'
+        marker_absent: true
+        sed_command: |-
+          /#define NVTX3_RANGE_ADD_PAYLOAD(N, S, P)/a\
+          #define NCCL_NVTX3_FUNC_RANGE
+        description: >
+          Extend RCCL's NVTX stub header with a no-op NCCL_NVTX3_FUNC_RANGE
+          definition. Several sources use that macro through core.h, so once
+          nvtx.h honors NVTX_NO_IMPL the stub path must also provide the same
+          API surface.
+
+      # 10. Disable hipBLASLt ROCTX marker support when profiler stack is disabled
+      - type: sed
+        file: "math-libs/BLAS/CMakeLists.txt"
+        marker: "-DHIPBLASLT_ENABLE_MARKER=OFF"
+        marker_absent: true
+        sed_command: '/-DHIPBLASLT_ENABLE_THEROCK=ON/a\    -DHIPBLASLT_ENABLE_MARKER=OFF'
+        description: >
+          Disable hipBLASLt's optional ROCTX marker integration. hipBLASLt
+          enables markers by default when BUILD_SHARED_LIBS is on, and then
+          hard-fails if roctx64 is not present. That conflicts with
+          THEROCK_ENABLE_PROFILER=OFF, where roctracer/roctx64 are intentionally
+          not built.
+
+      - type: sed
+        file: "math-libs/BLAS/CMakeLists.txt"
+        marker: "-DHIPSPARSELT_ENABLE_MARKER=OFF"
+        marker_absent: true
+        sed_command: '/-DHIPSPARSELT_ENABLE_THEROCK=ON/a\    -DHIPSPARSELT_ENABLE_MARKER=OFF'
+        description: >
+          Disable hipSPARSELt's optional ROCTX marker integration. hipSPARSELt
+          defaults HIPSPARSELT_ENABLE_MARKER to ON on non-Windows builds and
+          then hard-requires roctx64/roctracer during configure, which is
+          incompatible with THEROCK_ENABLE_PROFILER=OFF.
+
+      - type: sed
+        file: "ml-libs/CMakeLists.txt"
+        marker: "-DMIOPEN_USE_ROCTRACER=OFF"
+        marker_absent: true
+        sed_command: '/-DMIOPEN_USE_COMPOSABLEKERNEL=/a\      -DMIOPEN_USE_ROCTRACER=OFF'
+        description: >
+          Disable MIOpen's optional rocTracer/ROCTX integration. MIOpen
+          enables MIOPEN_USE_ROCTRACER by default and then probes for
+          roctracer/roctx.h and roctx64 during configure, which fails when
+          THEROCK_ENABLE_PROFILER=OFF intentionally omits the profiler stack.
+
+      # 11. Disable rocBLAS ROCTX integration when profiler stack is disabled
+      - type: sed
+        file: "math-libs/BLAS/CMakeLists.txt"
+        marker: "-DROCTX=OFF"
+        marker_absent: true
+        sed_command: '0,/-DLINK_BLIS=OFF/s//-DLINK_BLIS=OFF\
+    -DROCTX=OFF/'
+        description: >
+          Disable rocBLAS's optional ROCTX integration. rocBLAS later probes
+          for roctracer headers and roctx when this path is enabled, which
+          conflicts with THEROCK_ENABLE_PROFILER=OFF where those profiler
+          components are intentionally unavailable.
+
+      - type: sed
+        file: "math-libs/BLAS/CMakeLists.txt"
+        marker: "-DBUILD_WITH_ROCTX=OFF"
+        marker_absent: true
+        sed_command: '0,/-DBUILD_CLIENTS_SAMPLES=OFF/s//-DBUILD_CLIENTS_SAMPLES=OFF\
+    -DBUILD_WITH_ROCTX=OFF/'
+        description: >
+          Disable rocSPARSE's optional ROCTX tracing path at the TheRock
+          subproject layer. rocSPARSE already guards its roctx header/library
+          probing with BUILD_WITH_ROCTX, but TheRock does not currently pass
+          that option, so profiler-disabled builds still fail in the explicit
+          find_path/find_library override.
+
+      - type: sed
+        file: "rocm-libraries/projects/rocblas/library/CMakeLists.txt"
+        marker: "if(BUILD_SHARED_LIBS)"
+        sed_command: 's|if(BUILD_SHARED_LIBS)|if(BUILD_SHARED_LIBS AND ROCTX)|'
+        description: >
+          Gate rocBLAS's shared-library ROCTX header/library probing on the
+          ROCTX cache option as well. Upstream currently probes roctracer/roctx.h
+          whenever BUILD_SHARED_LIBS is on, so TheRock still fails in
+          projects/rocblas/library/CMakeLists.txt even when -DROCTX=OFF was
+          injected at the super-project layer.
+      - type: sed
+        file: "rocm-libraries/projects/rocblas/library/CMakeLists.txt"
+        marker: 'add_compile_definitions("DISABLE_ROCTX")'
+        marker_absent: true
+        sed_command: '/--unwindlib=libgcc)/a \
+  if(NOT ROCTX)\n    add_compile_definitions("DISABLE_ROCTX")\n  endif()'
+        description: >
+          When ROCTX is explicitly disabled, still define DISABLE_ROCTX for
+          rocBLAS sources before the shared-library probe block. This keeps
+          files like logging.cpp from including roctracer/roctx.h after the
+          find_path()/find_library() probe itself has been skipped.
+
   # ---------------------------------------------------------------------------
   # Phase B: CPU Libraries + Python
   # ---------------------------------------------------------------------------
@@ -355,7 +567,7 @@ packages:
     src_dir: "aocl-utils"
     method: cmake
     phase: B
-    steps: [5]
+    steps: [6]
     depends_on: [therock]
     compiler: amdclang
     skip_marker: "lib/libaoclutils.so"
@@ -378,7 +590,7 @@ packages:
     src_dir: "aocl-libm"
     method: scons
     phase: B
-    steps: [6]
+    steps: [7]
     depends_on: [therock, aocl_utils]
     compiler: amdclang
     skip_marker: "lib/libalm.so"
@@ -443,7 +655,7 @@ packages:
     src_dir: "cpython"
     method: autoconf
     phase: B
-    steps: [7]
+    steps: [8]
     depends_on: [therock]
     compiler: amdclang
     skip_marker: "bin/python3"
@@ -468,7 +680,7 @@ packages:
     src_dir: ".venv"
     method: venv
     phase: B
-    steps: [8]
+    steps: [9]
     depends_on: [cpython]
     build_dependencies:
       - pip
@@ -482,9 +694,10 @@ packages:
       - packaging
       - mako
     notes: |
-      Virtual environment using our source-built Python 3.13.
-      If the venv exists but points to a different Python binary
-      (e.g., system python), it is recreated with our build.
+      Canonical final virtual environment using our source-built Python 3.13.
+      Step 2 creates a bootstrap venv from system python3 so early TheRock
+      build-dependency installs always happen inside a managed environment.
+      Step 9 recreates this venv with the optimized Python build when available.
 
       Essential build tools installed: pip, ninja, cmake, wheel, setuptools,
       CppHeaderParser, meson, PyYAML, packaging, mako.
@@ -503,7 +716,7 @@ packages:
     clean_generated: true
     method: pip
     phase: C
-    steps: [9, 10, 11]
+    steps: [10, 11, 12]
     depends_on: [therock, cpython]
     compiler: amdclang
     skip_marker: null
@@ -559,18 +772,29 @@ packages:
           numpy 2.x headers compile against oldest compatible API (1.20),
           producing a .so that crashes at import with numpy 2.x installed.
 
-      # 2. Remove -fclang-abi-compat=17 (ABI mismatch with amdclang 22)
+      # 2. Remove host-side -fclang-abi-compat=17 (ABI mismatch with amdclang 22)
+      - type: sed
+        file: "CMakeLists.txt"
+        marker: 'append_cxx_flag_if_supported("-fclang-abi-compat=17" CMAKE_CXX_FLAGS)'
+        sed_command: 's/append_cxx_flag_if_supported(\"-fclang-abi-compat=17\" CMAKE_CXX_FLAGS)/# Removed: causes ABI mismatch with amdclang 22/'
+        description: >
+          Remove the top-level host C++ ABI compatibility override. The ROCm
+          fork also injects -fclang-abi-compat=17 into CMAKE_CXX_FLAGS for
+          Clang >= 18, which can still leave torch host objects mangled for
+          the Clang 17 ABI and trigger unresolved symbols at import time.
+
+      # 3. Remove HIP-side -fclang-abi-compat=17 (ABI mismatch with amdclang 22)
       - type: sed
         file: "cmake/Dependencies.cmake"
         marker: "fclang-abi-compat=17"
-        sed_command: "s/list(APPEND HIP_HIPCC_FLAGS -fclang-abi-compat=17)/# Removed: causes ABI mismatch with host amdclang 22/"
+        sed_command: "s/[[:space:]]-fclang-abi-compat=17//g"
         description: >
           Remove -fclang-abi-compat=17 from HIPCC flags. PyTorch adds it
           for compat with newer hip-clang C++20 mangling rules, but it
           forces HIP device code to use Clang 17 ABI while host code uses
           amdclang 22 ABI, causing undefined symbol errors.
 
-      # 3. Add gfx1151 to CK GEMM supported architectures
+      # 4. Add gfx1151 to CK GEMM supported architectures
       - type: sed
         file: "aten/src/ATen/Context.cpp"
         marker: "gfx1151"
@@ -582,7 +806,7 @@ packages:
           architecture!" and TunableOp cannot include CK kernels in its
           autotuning candidates. The gate is a hardcoded vector of arch strings.
 
-      # 4. Remove HIPGraph.hip dead code (CUDA 12.4+ type with no HIP equivalent)
+      # 5. Remove HIPGraph.hip dead code (CUDA 12.4+ type with no HIP equivalent)
       - type: file_rewrite
         file: "aten/src/ATen/hip/HIPGraph.hip"
         marker: "cudaGraphConditionalHandle"
@@ -595,41 +819,33 @@ packages:
           minimal stub containing only the namespace declaration.
         note: "Content is a heredoc in build-vllm.sh (too complex for YAML inline)"
 
-      # 5. Wheel RPATH: fix build tree paths in torch/lib/*.so
+      # 5. Wheel RPATH: normalize torch/lib/*.so search path
       - type: patchelf_rpath
         target: "torch/lib/lib*.so"
-        condition: "RUNPATH contains 'pytorch/build'"
-        rpath: "${LOCAL_PREFIX}/lib:$ORIGIN"
+        rpath: "${LOCAL_PREFIX}/lib:${LOCAL_PREFIX}/lib/llvm/lib:$ORIGIN"
         action: set
         description: >
-          Fix RPATHs inside PyTorch wheel. cmake bakes build tree path
-          (e.g. /opt/src/vllm/pytorch/build/lib) into RUNPATH, causing
-          the dynamic linker to load unpatched .so files from the build
-          tree instead of the wheel's copies.
+          Normalize every torch/lib/*.so RPATH inside the PyTorch wheel.
+          cmake can leak the build tree path (e.g.
+          /opt/src/vllm/pytorch/build/lib) into RUNPATH, causing the
+          dynamic linker to mix build-tree and installed wheel
+          libraries. Replacing it with only the local runtime dirs and
+          $ORIGIN keeps torch's shared libraries self-consistent and
+          also makes clang's OpenMP runtime resolvable without
+          LD_LIBRARY_PATH.
 
-      # 6. Wheel RPATH: add ROCm lib path to .so files that reference ROCm libs
-      - type: patchelf_rpath
-        target: "torch/lib/lib*.so"
-        condition: "NEEDED contains libalm.so, libamdhip64, or librocm_smi"
-        rpath: "${LOCAL_PREFIX}/lib"
-        action: add
-        description: >
-          Add ROCm lib path to .so files that dynamically link ROCm
-          libraries (libalm.so, libamdhip64, librocm_smi64) so they
-          resolve without LD_LIBRARY_PATH at runtime.
-
-      # 7. Wheel RPATH: fix _C extension module build tree path
+      # 6. Wheel RPATH: normalize torch/_C*.so search path
       - type: patchelf_rpath
         target: "torch/_C*.so"
-        condition: "RUNPATH contains 'pytorch/build'"
-        rpath: "${LOCAL_PREFIX}/lib:$ORIGIN/lib"
+        rpath: "${LOCAL_PREFIX}/lib:${LOCAL_PREFIX}/lib/llvm/lib:$ORIGIN/lib"
         action: set
         description: >
-          Fix the _C extension module RPATH. Same build tree path issue
-          as torch/lib/*.so but needs $ORIGIN/lib to find sibling .so
-          files in the wheel's lib/ subdirectory.
+          Normalize the _C extension module RPATH. It has the same
+          build-tree leakage risk as torch/lib/*.so, but also needs
+          $ORIGIN/lib to find sibling torch libraries in the wheel's
+          lib/ subdirectory.
 
-      # 8. Wheel NEEDED: add librocm_smi64.so to libtorch_hip.so
+      # 7. Wheel NEEDED: add librocm_smi64.so to libtorch_hip.so
       - type: patchelf_needed
         target: "torch/lib/libtorch_hip.so"
         library: "librocm_smi64.so"
@@ -640,12 +856,24 @@ packages:
           symbols -- upstream bug that causes "undefined symbol: rsmi_init"
           at runtime.
 
+      # 8. Wheel NEEDED: add clang OpenMP runtime to torch._C extension
+      - type: patchelf_needed
+        target: "torch/_C*.so"
+        library: "libomp.so or libiomp5.so from ${LOCAL_PREFIX}/lib{,/llvm/lib}"
+        condition: "NEEDED does not contain an OpenMP runtime"
+        description: >
+          Add clang's OpenMP runtime to the torch._C extension when the
+          wheel omits it. This ensures libomp/libiomp5 is loaded at
+          import time without mutating libtorch_cpu.so itself, avoiding
+          the original "__kmpc_fork_call" failure while keeping torch's
+          internal library dependency graph unchanged.
+
   torchvision:
     repo: "https://github.com/pytorch/vision.git"
     src_dir: "torchvision"
     method: pip
     phase: C
-    steps: [12, 13]
+    steps: [13, 14]
     depends_on: [pytorch]
     compiler: amdclang
     skip_marker: null
@@ -674,7 +902,7 @@ packages:
     validate_remote: "ROCm/triton"
     method: pip
     phase: D
-    steps: [14, 15, 16]
+    steps: [15, 16, 17]
     depends_on: [therock, pytorch]
     compiler: amdclang
     skip_marker: null
@@ -750,7 +978,7 @@ packages:
     src_dir: "aotriton"
     method: cmake
     phase: D
-    steps: [17, 18]
+    steps: [18, 19]
     depends_on: [triton]
     compiler: amdclang
     skip_marker: "lib/libaotriton_v2.so"
@@ -779,9 +1007,10 @@ packages:
   vllm:
     repo: "https://github.com/vllm-project/vllm.git"
     src_dir: "vllm"
+    clean_generated: true
     method: pip
     phase: E
-    steps: [19, 20, 21, 22, 23, 24]
+    steps: [20, 21, 22, 23, 24, 25]
     depends_on: [pytorch, triton, aotriton]
     compiler: amdclang
     skip_marker: null
@@ -937,24 +1166,7 @@ packages:
           to raise "RuntimeError: Duplicate pattern" and crash the engine.
           This prevents torch.compile from working, forcing --enforce-eager.
 
-      # 10. Triton sampler bypass: gfx1151 page fault after torch.compile AOT
-      - type: sed
-        file: "vllm/v1/sample/ops/topk_topp_sampler.py"
-        marker: "NOTE(gfx1151)"
-        marker_absent: true
-        sed_command: >
-          /if HAS_TRITON and logits.shape\[0\] >= 8:/,+2{
-            s|    if HAS_TRITON.*|    # NOTE(gfx1151): The Triton top-k/top-p kernel page-faults on RDNA 3.5\n    # after torch.compile AOT compilation. Use the PyTorch sort path instead.\n    # if HAS_TRITON and logits.shape[0] >= 8:\n    #     return apply_top_k_top_p_triton(logits, k, p)|;
-            /return apply_top_k_top_p_triton/d
-          }
-        description: >
-          Comment out the Triton top-k/top-p sampler kernel path. On gfx1151,
-          the Triton kernel page-faults after torch.compile AOT compilation
-          has rewritten the sampling graph. The PyTorch sort-based path
-          (apply_top_k_top_p_pytorch) is functionally identical and works
-          correctly on all architectures.
-
-      # 11. FLA chunk_delta_h: AMD autotune restrict + exp() float32 cast
+      # 10. FLA chunk_delta_h: AMD autotune restrict + exp() float32 cast
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_delta_h.py"
         marker: "is_amd"
@@ -964,7 +1176,7 @@ packages:
           Import is_amd flag from utils for conditional autotune configuration
           in chunk_delta_h.py. Part 1 of 3 for the FLA AMD fixes.
 
-      # 12. FLA chunk_delta_h: restrict autotune search on AMD
+      # 11. FLA chunk_delta_h: restrict autotune search on AMD
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_delta_h.py"
         marker: "if is_amd else"
@@ -978,7 +1190,7 @@ packages:
           pipeline stages cause GPU page faults during autotuning on RDNA 3.5
           (gfx1151, wave32). The CDNA path (gfx9) retains the full search.
 
-      # 13. FLA chunk_delta_h: restrict BV autotune on AMD
+      # 12. FLA chunk_delta_h: restrict BV autotune on AMD
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_delta_h.py"
         marker: "\\[32\\] if is_amd"
@@ -988,7 +1200,7 @@ packages:
           Restrict Triton autotune BV to 32 on AMD HIP. BV=64 with K>64
           produces kernels that page-fault on RDNA 3.5 during autotuning.
 
-      # 14. FLA chunk_delta_h: cast exp() operands to float32 on HIP
+      # 13. FLA chunk_delta_h: cast exp() operands to float32 on HIP
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_delta_h.py"
         marker: "b_g_diff"
@@ -1003,7 +1215,7 @@ packages:
           correctly for exp(scalar_bf16 - block_ptr_load_bf16), producing
           invalid IR. Explicit float32 cast also improves precision.
 
-      # 15. FLA chunk_delta_h: cast b_g_last to float32 in second exp()
+      # 14. FLA chunk_delta_h: cast b_g_last to float32 in second exp()
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_delta_h.py"
         marker: "b_g_last.to(tl.float32))"
@@ -1013,7 +1225,7 @@ packages:
           Cast b_g_last to float32 before the second exp() call in
           chunk_delta_h. Same type inference issue as patch 14.
 
-      # 16. FLA qwen3_next warmup: restrict to T=(64,)
+      # 15. FLA qwen3_next warmup: restrict to T=(64,)
       - type: sed
         file: "vllm/model_executor/models/qwen3_next.py"
         marker: "NOTE(gfx1151)"
@@ -1028,7 +1240,7 @@ packages:
           This only affects the warmup path -- actual inference always uses
           T >= chunk_size for prefill and the chunk loop for decode.
 
-      # 17. Rotary embedding: flash_attn import try/except
+      # 16. Rotary embedding: flash_attn import try/except
       - type: sed
         file: "vllm/model_executor/layers/rotary_embedding/common.py"
         marker: "flash_attn may be installed"
@@ -1045,7 +1257,7 @@ packages:
           flash_attn_2_cuda) fails with ImportError. The fallback is vLLM's
           own rotary implementation which works on all platforms.
 
-      # 18. AITER RMSNorm: Triton dispatch for gfx1x (fused_add variant)
+      # 17. AITER RMSNorm: Triton dispatch for gfx1x (fused_add variant)
       - type: file_rewrite
         file: "vllm/_aiter_ops.py"
         marker: "rmsnorm2d_fwd_with_add_dynamicquant"
@@ -1060,7 +1272,7 @@ packages:
           Complex multi-line replacement handled in build-vllm.sh with
           Python script (too complex for YAML sed expression).
 
-      # 19. AITER RMSNorm: Triton dispatch for gfx1x (plain variant)
+      # 18. AITER RMSNorm: Triton dispatch for gfx1x (plain variant)
       - type: file_rewrite
         file: "vllm/_aiter_ops.py"
         marker: "rmsnorm2d_fwd_with_dynamicquant"
@@ -1072,7 +1284,7 @@ packages:
           Applied together with patch 18 by the same Python script in
           build-vllm.sh.
 
-      # 20. FLA chunk_o.py: add is_amd import
+      # 19. FLA chunk_o.py: add is_amd import
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_o.py"
         marker: "is_amd"
@@ -1082,7 +1294,7 @@ packages:
           Add is_amd to the utils import in chunk_o.py. Required by patches
           21-23 which restrict autotune parameters on AMD HIP.
 
-      # 21. FLA chunk_o.py: restrict BK autotune on AMD
+      # 20. FLA chunk_o.py: restrict BK autotune on AMD
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_o.py"
         marker: "32\\] if is_amd else BKV_LIST"
@@ -1093,7 +1305,7 @@ packages:
           kernel page-faults during autotuning on RDNA 3.5 with BK>32 and
           num_stages>2. Same class of fix as chunk_delta_h patches 13-15.
 
-      # 22. FLA chunk_o.py: restrict BV autotune on AMD
+      # 21. FLA chunk_o.py: restrict BV autotune on AMD
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_o.py"
         marker: "32\\] if is_amd else BKV_LIST"
@@ -1104,7 +1316,7 @@ packages:
           patch 21 — large tile sizes produce code that causes GPU page faults
           during autotuning on RDNA 3.5 (wave32).
 
-      # 23. FLA chunk_o.py: restrict num_stages autotune on AMD
+      # 22. FLA chunk_o.py: restrict num_stages autotune on AMD
       - type: sed
         file: "vllm/model_executor/layers/fla/ops/chunk_o.py"
         marker: "\\[2\\] if is_amd"
@@ -1114,7 +1326,7 @@ packages:
           Restrict Triton autotune num_stages to 2 on AMD HIP. Higher pipeline
           stages produce code that page-faults on RDNA 3.5 during autotuning.
 
-      # 24. config/vllm.py: re-run hybrid alignment after platform config
+      # 23. config/vllm.py: re-run hybrid alignment after platform config
       - type: file_rewrite
         file: "vllm/config/vllm.py"
         marker: "Re-run hybrid alignment"
@@ -1129,7 +1341,7 @@ packages:
           Complex multi-line insertion handled in build-vllm.sh with
           Python script (too complex for YAML sed expression).
 
-      # 25. models/config.py: platform block_size as alignment minimum
+      # 24. models/config.py: platform block_size as alignment minimum
       - type: file_rewrite
         file: "vllm/model_executor/models/config.py"
         marker: "platform already set a minimum"
@@ -1146,7 +1358,7 @@ packages:
           Complex multi-line insertion handled in build-vllm.sh with
           Python script (too complex for YAML sed expression).
 
-      # 26. rocm.py: skip AITER attention backends for hybrid models [TESTING]
+      # 25. rocm.py: skip AITER attention backends for hybrid models [TESTING]
       - type: file_rewrite
         file: "vllm/platforms/rocm.py"
         marker: "_is_hybrid"
@@ -1162,7 +1374,7 @@ packages:
           Complex multi-line insertion handled in build-vllm.sh with
           Python script (too complex for YAML sed expression).
 
-      # 27. rocm_aiter_unified_attn.py: power-of-2 block_size check [TESTING]
+      # 26. rocm_aiter_unified_attn.py: power-of-2 block_size check [TESTING]
       - type: file_rewrite
         file: "vllm/v1/attention/backends/rocm_aiter_unified_attn.py"
         marker: "block_size - 1"
@@ -1188,7 +1400,7 @@ packages:
     src_dir: "flash-attention"
     method: pip
     phase: F
-    steps: [25, 26, 27, 28]
+    steps: [26, 27, 28, 29]
     depends_on: [pytorch, triton, vllm]
     compiler: amdclang
     skip_marker: null
@@ -1231,7 +1443,7 @@ packages:
     src_dir: "pytorch/third_party/aiter"
     method: pip
     phase: F
-    steps: [28]
+    steps: [29]
     depends_on: [pytorch, vllm]
     compiler: amdclang
     skip_marker: null
@@ -1344,7 +1556,7 @@ packages:
   rust_wheels:
     method: cargo
     phase: H
-    steps: [30]
+    steps: [31]
     depends_on: [cpython]
     notes: |
       Builds and installs orjson and cryptography from source with Rust flags:
@@ -1365,7 +1577,7 @@ packages:
   native_wheels:
     method: pip
     phase: H
-    steps: [31]
+    steps: [32]
     depends_on: [cpython, pytorch]
     notes: |
       Builds and installs numpy, sentencepiece, zstandard, asyncpg, duckdb from
@@ -1393,7 +1605,7 @@ packages:
   source_wheels:
     method: export
     phase: H
-    steps: [32]
+    steps: [33]
     depends_on: [pytorch, triton, torchvision, vllm]
     notes: |
       Packages torch, triton, torchvision, amd-aiter, amdsmi as
@@ -1414,7 +1626,7 @@ packages:
     shallow: true
     method: cmake
     phase: I
-    steps: [33]
+    steps: [34]
     depends_on: [therock]
     compiler: amdclang
     skip_marker: null
@@ -1471,7 +1683,7 @@ packages:
     shallow: true
     method: pip
     phase: I
-    steps: [33, 34, 35]
+    steps: [34, 35, 36]
     depends_on: [therock, llamacpp]
     compiler: system
     skip_marker: null

--- a/strix-halo/vllm-runtime-helpers.sh
+++ b/strix-halo/vllm-runtime-helpers.sh
@@ -245,13 +245,46 @@ vllm_query_models() {
 # Returns:
 #   0 on success, dies if rocm-smi query fails
 vllm_gtt_total_mb() {
-    local gtt_bytes
-    gtt_bytes="$(rocm-smi --showmeminfo gtt 2>/dev/null \
-        | grep "GTT Total Memory" \
-        | grep -oP '\d+$')"
-    if [[ -z "${gtt_bytes}" ]]; then
+    local visible_device
+    local -a rocm_smi_args=(--showmeminfo gtt)
+    local -a gtt_values=()
+
+    # If HIP_VISIBLE_DEVICES is set, query the first selected GPU only.
+    # This avoids multi-line output on multi-GPU hosts, which breaks arithmetic.
+    visible_device="${HIP_VISIBLE_DEVICES%%,*}"
+    if [[ -n "${visible_device}" ]]; then
+        rocm_smi_args=(--device "${visible_device}" "${rocm_smi_args[@]}")
+    fi
+
+    while IFS= read -r value; do
+        value="$(echo "${value}" | tr -cd '0-9')"
+        if [[ -n "${value}" ]]; then
+            gtt_values+=("${value}")
+        fi
+    done < <(rocm-smi "${rocm_smi_args[@]}" 2>/dev/null | awk '/GTT Total Memory/ {print $NF}')
+
+    if [[ "${#gtt_values[@]}" -eq 0 ]]; then
         die "Cannot query GTT memory from rocm-smi. Is ROCm installed?"
     fi
+
+    local gtt_bytes
+    if [[ "${#gtt_values[@]}" -eq 1 ]]; then
+        gtt_bytes="${gtt_values[0]}"
+    elif [[ -n "${visible_device}" ]]; then
+        # Some APUs expose multiple partitions for a single visible GPU; sum
+        # all reported slices so utilization math reflects the full pool.
+        local sum=0
+        local part
+        for part in "${gtt_values[@]}"; do
+            sum=$((sum + part))
+        done
+        gtt_bytes="${sum}"
+    else
+        # Without explicit device scoping, avoid summing across potentially
+        # unrelated GPUs by using the first reported device's value.
+        gtt_bytes="${gtt_values[0]}"
+    fi
+
     echo $(( gtt_bytes / 1048576 ))
 }
 

--- a/strix-halo/vllm-start.sh
+++ b/strix-halo/vllm-start.sh
@@ -55,10 +55,142 @@ vllm_load_env "${ENV_FILE}"
 VLLM_HOST="${VLLM_HOST:-0.0.0.0}"
 VLLM_STARTUP_TIMEOUT="${VLLM_STARTUP_TIMEOUT:-180}"
 VLLM_PREFIX_CACHING_HASH_ALGO="${VLLM_PREFIX_CACHING_HASH_ALGO:-xxhash}"
+VLLM_STARTUP_ERROR_TAIL_LINES="${VLLM_STARTUP_ERROR_TAIL_LINES:-120}"
+VLLM_MAX_GPU_MEMORY_UTILIZATION="${VLLM_MAX_GPU_MEMORY_UTILIZATION:-0.98}"
+
+# Print a startup failure summary from a vLLM log file.
+#
+# Args:
+#   log_file - Path to vLLM instance log file
+vllm_print_startup_failure_details() {
+    local log_file="$1"
+    local traceback_context_lines="${VLLM_STARTUP_TRACEBACK_CONTEXT_LINES:-40}"
+
+    if [[ ! -f "${log_file}" ]]; then
+        error "No startup log found at ${log_file}"
+        return
+    fi
+
+    # vLLM often emits a generic RuntimeError at the end of startup failure.
+    # Printing where the first traceback starts helps locate root cause quickly.
+    local first_traceback_line
+    first_traceback_line="$(grep -n -m1 "Traceback (most recent call last)" "${log_file}" \
+        | cut -d: -f1 || true)"
+    if [[ -n "${first_traceback_line}" ]]; then
+        error "First traceback starts at line ${first_traceback_line} in ${log_file}"
+
+        # Print focused context around the first traceback, because vLLM often
+        # reports the true engine/core failure immediately before it.
+        local context_start context_end
+        context_start=$(( first_traceback_line - traceback_context_lines ))
+        if [[ "${context_start}" -lt 1 ]]; then
+            context_start=1
+        fi
+        context_end=$(( first_traceback_line + traceback_context_lines ))
+        error "Context around first traceback (lines ${context_start}-${context_end}):"
+        sed -n "${context_start},${context_end}p" "${log_file}" >&2
+    fi
+
+    error "Last ${VLLM_STARTUP_ERROR_TAIL_LINES} lines from ${log_file}:"
+    tail -"${VLLM_STARTUP_ERROR_TAIL_LINES}" "${log_file}" >&2
+}
 
 # =============================================================================
 # Instance Management
 # =============================================================================
+
+
+# Detect known torch.compile duplicate-pattern crash in ROCm AITER RMSNorm fusion.
+#
+# Args:
+#   log_file - Path to vLLM instance log file
+# Returns:
+#   0 if duplicate-pattern signature found, 1 otherwise
+vllm_is_aiter_rmsnorm_duplicate_pattern_failure() {
+    local log_file="$1"
+
+    [[ -f "${log_file}" ]] || return 1
+
+    grep -q "rocm_aiter_fusion.py" "${log_file}" \
+        && grep -q "check_and_add_duplicate_pattern" "${log_file}"
+}
+
+# Print targeted diagnostics for the duplicate-pattern startup crash.
+#
+# This focuses on root-cause indicators instead of only applying fallbacks:
+#   - Installed vLLM / torch / triton versions
+#   - rocm_aiter_fusion.py path from the active Python environment
+#   - Whether skip_duplicates=True is present on register_replacement calls
+#
+# Args:
+#   role - Logical instance role (main, etc.) for log prefixing
+vllm_print_duplicate_pattern_diagnostics() {
+    local role="$1"
+
+    info "${role}: collecting duplicate-pattern diagnostics (versions + patch state)"
+    python - <<'PY'
+import importlib.util
+import os
+import re
+import sys
+
+def _safe_import(name):
+    try:
+        mod = __import__(name)
+        return mod, None
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        return None, exc
+
+vllm, vllm_err = _safe_import("vllm")
+torch, torch_err = _safe_import("torch")
+triton, triton_err = _safe_import("triton")
+
+print("  diag  Python executable:", sys.executable)
+print("  diag  vLLM version:      ", getattr(vllm, "__version__", f"<import failed: {vllm_err}>"))
+print("  diag  torch version:     ", getattr(torch, "__version__", f"<import failed: {torch_err}>"))
+print("  diag  triton version:    ", getattr(triton, "__version__", f"<import failed: {triton_err}>"))
+
+target = None
+if vllm is not None:
+    spec = importlib.util.find_spec("vllm.compilation.passes.fusion.rocm_aiter_fusion")
+    if spec is not None:
+        target = spec.origin
+
+if not target or not os.path.isfile(target):
+    print("  diag  rocm_aiter_fusion: <not found in active environment>")
+    raise SystemExit(0)
+
+print("  diag  rocm_aiter_fusion: ", target)
+try:
+    text = open(target, "r", encoding="utf-8").read()
+except Exception as exc:  # pragma: no cover - diagnostics only
+    print(f"  diag  patch check:       <failed to read file: {exc}>")
+    raise SystemExit(0)
+
+try:
+    register_calls = len(re.findall(r"pm\.register_replacement\(", text))
+    skip_dupe = len(
+        re.findall(
+            r"pm\.register_replacement\([^\n]*skip_duplicates\s*=\s*True",
+            text,
+        )
+    )
+except re.error as exc:  # pragma: no cover - diagnostics only
+    print(f"  diag  regex check:       <failed: {exc}>")
+    raise SystemExit(0)
+
+print("  diag  register calls:    ", register_calls)
+print("  diag  skip_duplicates=:  ", skip_dupe)
+
+if register_calls and skip_dupe == 0:
+    print("  diag  likely root cause: active wheel is missing the skip_duplicates patch")
+    print("  diag  action: rebuild/reinstall vLLM so rocm_aiter_fusion.py includes skip_duplicates=True")
+elif register_calls and skip_dupe < register_calls:
+    print("  diag  likely root cause: partial patch application in rocm_aiter_fusion.py")
+else:
+    print("  diag  patch state:       skip_duplicates appears present")
+PY
+}
 
 start_instance() {
     local role="$1"
@@ -129,6 +261,10 @@ start_instance() {
         local total_mb utilization
         total_mb="$(vllm_gtt_total_mb)"
         utilization="$(vllm_mb_to_utilization "${gpu_memory_mb}" "${total_mb}")"
+        if [[ "$(echo "${utilization} > ${VLLM_MAX_GPU_MEMORY_UTILIZATION}" | bc)" -eq 1 ]]; then
+            warn "${role}: requested ${gpu_memory_mb}MB exceeds detected ${total_mb}MB; capping --gpu-memory-utilization to ${VLLM_MAX_GPU_MEMORY_UTILIZATION}"
+            utilization="${VLLM_MAX_GPU_MEMORY_UTILIZATION}"
+        fi
         cmd_args+=(--gpu-memory-utilization "${utilization}")
         info "${role}: GPU memory ${gpu_memory_mb}MB / ${total_mb}MB = ${utilization}"
     fi
@@ -137,37 +273,77 @@ start_instance() {
     # shellcheck disable=SC2206
     cmd_args+=(${extra_args})
 
-    info "Starting vLLM ${role}: ${model} on ${device}:${port}"
-    info "Log file: ${log_file}"
+    # Preferred switch: explicit enable for one-time retry fallback.
+    # Legacy compatibility: if VLLM_DISABLE_AITER_RMSNORM_ON_DUP_PATTERN=1 is
+    # set, treat that as enabled as well.
+    local enable_rmsnorm_retry="${VLLM_ENABLE_AITER_RMSNORM_DUP_PATTERN_RETRY:-0}"
+    if [[ "${enable_rmsnorm_retry}" != "1" ]] \
+        && [[ "${VLLM_DISABLE_AITER_RMSNORM_ON_DUP_PATTERN:-0}" == "1" ]]; then
+        enable_rmsnorm_retry="1"
+    fi
+    local launch_with_rmsnorm_disabled=0
+    local attempt
 
-    # Launch in background with per-process VLLM_TARGET_DEVICE.
-    VLLM_TARGET_DEVICE="${device}" nohup "${cmd_args[@]}" > "${log_file}" 2>&1 &
+    for attempt in 1 2; do
+        info "Starting vLLM ${role}: ${model} on ${device}:${port} (attempt ${attempt}/2)"
+        info "Log file: ${log_file}"
 
-    local instance_pid=$!
-    echo "${instance_pid}" > "${pid_file}"
-
-    # Health check loop.
-    info "Waiting for ${role} health check (timeout: ${VLLM_STARTUP_TIMEOUT}s)..."
-
-    if vllm_poll_health "${VLLM_HOST}" "${port}" "${VLLM_STARTUP_TIMEOUT}" "${instance_pid}"; then
-        success "vLLM ${role} ready (PID: ${instance_pid}, port: ${port})"
-
-        # Log which attention backend was actually selected (parse vLLM log).
-        local backend_line
-        backend_line="$(grep -oP 'Using \K\S+ out of potential backends' "${log_file}" 2>/dev/null | head -1)"
-        if [[ -n "${backend_line}" ]]; then
-            info "${role}: ${backend_line}"
+        # Launch in background with per-process VLLM_TARGET_DEVICE.
+        local -a launch_env=(
+            VLLM_TARGET_DEVICE="${device}"
+        )
+        if [[ "${launch_with_rmsnorm_disabled}" -eq 1 ]]; then
+            launch_env+=(VLLM_ROCM_USE_AITER_RMSNORM=0)
         fi
-        return 0
-    fi
+        env "${launch_env[@]}" nohup "${cmd_args[@]}" > "${log_file}" 2>&1 &
 
-    # Failed: check if process died or timed out.
-    if ! kill -0 "${instance_pid}" 2>/dev/null; then
-        error "vLLM ${role} (PID ${instance_pid}) died during startup. Last 30 lines:"
-    else
-        error "vLLM ${role} did not become healthy within ${VLLM_STARTUP_TIMEOUT}s. Last 30 lines:"
-    fi
-    tail -30 "${log_file}" >&2
+        local instance_pid=$!
+        echo "${instance_pid}" > "${pid_file}"
+
+        # Health check loop.
+        info "Waiting for ${role} health check (timeout: ${VLLM_STARTUP_TIMEOUT}s)..."
+
+        if vllm_poll_health "${VLLM_HOST}" "${port}" "${VLLM_STARTUP_TIMEOUT}" "${instance_pid}"; then
+            success "vLLM ${role} ready (PID: ${instance_pid}, port: ${port})"
+
+            # Log which attention backend was actually selected (parse vLLM log).
+            local backend_line
+            backend_line="$(grep -oP 'Using \K\S+ out of potential backends' "${log_file}" 2>/dev/null | head -1)"
+            if [[ -n "${backend_line}" ]]; then
+                info "${role}: ${backend_line}"
+            fi
+            return 0
+        fi
+
+        # Failed: check if process died or timed out.
+        if ! kill -0 "${instance_pid}" 2>/dev/null; then
+            error "vLLM ${role} (PID ${instance_pid}) died during startup."
+        else
+            error "vLLM ${role} did not become healthy within ${VLLM_STARTUP_TIMEOUT}s."
+        fi
+
+        # Automatic one-time fallback for known duplicate pattern crash in
+        # RocmAiterRMSNormQuantFusionPass.
+        if [[ "${VLLM_ROCM_USE_AITER_RMSNORM:-0}" == "1" ]] \
+            && vllm_is_aiter_rmsnorm_duplicate_pattern_failure "${log_file}"; then
+            vllm_print_duplicate_pattern_diagnostics "${role}"
+
+            if [[ "${enable_rmsnorm_retry}" == "1" ]] \
+                && [[ "${launch_with_rmsnorm_disabled}" -eq 0 ]]; then
+                launch_with_rmsnorm_disabled=1
+                warn "${role}: detected AITER RMSNorm duplicate-pattern startup crash; retrying with VLLM_ROCM_USE_AITER_RMSNORM=0"
+                rm -f "${pid_file}"
+                continue
+            fi
+            warn "${role}: detected AITER RMSNorm duplicate-pattern startup crash"
+            warn "${role}: retry fallback is disabled (set VLLM_ENABLE_AITER_RMSNORM_DUP_PATTERN_RETRY=1 to enable one-time retry)"
+        fi
+
+        vllm_print_startup_failure_details "${log_file}"
+        rm -f "${pid_file}"
+        return 1
+    done
+
     rm -f "${pid_file}"
     return 1
 }


### PR DESCRIPTION
Cherry-picks the useful Dillflix/gfx1151-stack build and runtime hardening while keeping TheRock on upstream head builds instead of pinning a revision.

Includes bootstrap/final venv split, TheRock profiler-disabled patches, PyTorch/OpenMP diagnostics, smoke-test hardening, Lemonade compatibility, and vLLM startup diagnostics.