### PR TITLE
Fix file_copy parent directory creation

### DIFF
--- a/strix-halo/build-vllm.sh
+++ b/strix-halo/build-vllm.sh
@@ -861,6 +861,7 @@ apply_patches() {
                         continue
                     fi
                     info "  [${i}] ${p_description}"
+                    mkdir -p "$(dirname "${p_dst}")"
                     if [[ "${p_recursive}" == "true" ]]; then
                         cp -a "${p_src}" "${p_dst}"
                     else


### PR DESCRIPTION
This pull request makes a small but important change to the `apply_patches()` function in `strix-halo/build-vllm.sh`. Before copying files, it now ensures that the destination directory exists by creating it if necessary. This helps prevent errors when the target directory does not already exist.

closes issue #10 