### PR TITLE
Add stable-diffusion.cpp Vulkan build

### DIFF
--- a/strix-halo/README.md
+++ b/strix-halo/README.md
@@ -120,11 +120,12 @@ Phase H: Optimized Wheels (Zen 5 native builds for downstream venvs)
 
 Phase I: Lemonade Inference Server
   34. Clone Lemonade + build llama.cpp (ROCm hipBLAS + Vulkan backends)
-  35. Install Lemonade SDK from PyPI
-  36. Validate Lemonade (both backends)
+  35. Clone/build stable-diffusion.cpp (Vulkan backend)
+  36. Install Lemonade SDK from PyPI
+  37. Validate Lemonade + stable-diffusion.cpp
 
 Phase J: Backend Smoke Test
-  37. Validate all inference backends with SmolLM2
+  38. Validate all inference backends with SmolLM2
 ```
 
 ### Lemonade: Dual-Backend llama.cpp
@@ -141,6 +142,14 @@ two GPU backends, managed by the
 Both backends are installed into the venv and Lemonade can route between
 them based on workload. Each backend gets its own `.env` file with
 gfx1151 runtime optimizations (batch sizing, hipBLASLt, THP).
+
+### stable-diffusion.cpp: Vulkan Image Generation
+
+Phase I also builds [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp)
+from upstream `master` with the Vulkan backend for Strix Halo image generation.
+The build uses TheRock `amdclang`, Zen 5 native CPU flags, ThinLTO, AOCL-LibM,
+OpenMP, WebP/WebM support, and installs `sd-cli`/`sd-server` into
+`${VLLM_VENV}/vulkan/stable_diffusion`.
 
 ## Supported Distributions
 
@@ -250,7 +259,7 @@ all 40+ target features including AVX-512, VAES, VPCLMULQDQ, GFNI, SHA.
 
 | File | Description |
 |------|-------------|
-| `build-vllm.sh` | Master build script (37-step pipeline) |
+| `build-vllm.sh` | Master build script (38-step pipeline) |
 | `vllm-env.sh` | Environment activation (compiler flags, ROCm paths, venv) |
 | `vllm-packages.yaml` | Package manifest (repos, branches, patches, per-distro prerequisites, bootstrap config) |
 | `vllm-start.sh` | Start all vLLM inference instances (role-based, multi-model) |
@@ -278,6 +287,7 @@ all 40+ target features including AVX-512, VAES, VPCLMULQDQ, GFNI, SHA.
 | AOCL-LibM | amd/aocl-libm-ose | main |
 | AOCL-Utils | amd/aocl-utils | main |
 | llama.cpp | ggml-org/llama.cpp | master |
+| stable-diffusion.cpp | leejet/stable-diffusion.cpp | master |
 | Lemonade | lemonade-sdk/lemonade | v10.0.0 |
 
 Note: PyTorch, Triton, and Flash Attention use the **ROCm forks**, not

--- a/strix-halo/build-vllm.sh
+++ b/strix-halo/build-vllm.sh
@@ -29,7 +29,7 @@
 #   scripts/build-vllm.sh --rebuild   # Force rebuild (clean + build)
 #   scripts/build-vllm.sh --step N    # Run from step N onward
 #
-# Build pipeline (37 steps):
+# Build pipeline (38 steps):
 #   Phase A: ROCm SDK (TheRock — builds amdclang used by everything downstream)
 #     1. Clone TheRock          4. Build TheRock
 #     2. Create bootstrap venv  5. Validate ROCm
@@ -73,11 +73,12 @@
 #
 #   Phase I: Lemonade Inference Server (llama.cpp + FLM + ONNX)
 #    34. Clone Lemonade + build llama.cpp with hipBLAS for gfx1151
-#    35. Install Lemonade SDK from PyPI (lemonade-sdk)
-#    36. Validate Lemonade (server smoke test)
+#    35. Clone/build stable-diffusion.cpp with Vulkan for gfx1151
+#    36. Install Lemonade SDK from PyPI (lemonade-sdk)
+#    37. Validate Lemonade + stable-diffusion.cpp
 #
 #   Phase J: Backend Smoke Test
-#    37. Backend smoke test (all inference backends)
+#    38. Backend smoke test (all inference backends)
 
 set -euo pipefail
 
@@ -314,11 +315,13 @@ TORCHVISION_SRC="${VLLM_DIR}/$(pkg torchvision src_dir)"
 FLASH_ATTN_SRC="${VLLM_DIR}/$(pkg flash_attention src_dir)"
 LEMONADE_SRC="${VLLM_DIR}/$(pkg lemonade src_dir)"
 LLAMACPP_SRC="${VLLM_DIR}/$(pkg llamacpp src_dir)"
+STABLE_DIFFUSION_SRC="${VLLM_DIR}/$(pkg stable_diffusion_cpp src_dir)"
 
 # Lemonade backend install directories
 LLAMACPP_ROCM_DIR="${VLLM_VENV}/rocm/llama_server"
 LLAMACPP_VULKAN_DIR="${VLLM_VENV}/vulkan/llama_server"
 LLAMACPP_INSTALL_DIR="${LLAMACPP_ROCM_DIR}"
+STABLE_DIFFUSION_VULKAN_DIR="${VLLM_VENV}/vulkan/stable_diffusion"
 
 # Wheel output directory
 WHEELS_DIR="${VLLM_DIR}/wheels"
@@ -4012,7 +4015,7 @@ if failed > 0:
     success "AITER JIT pre-warm: ${built_count} modules compiled in ${jit_dir}"
 }
 
-# Step 37: Backend Smoke Test
+# Step 38: Backend Smoke Test
 # Downloads a tiny model (SmolLM2-135M-Instruct, ~270 MB FP16 / ~70 MB Q4 GGUF)
 # and runs actual inference through every installed backend:
 #   1. vLLM      – offline LLM inference + TunableOp CSV warmup as side effect
@@ -4025,7 +4028,7 @@ if failed > 0:
 # Individual backend failures are non-fatal — a summary table is printed at
 # the end showing PASS / FAIL / SKIP for each backend.
 backend_smoke_test() {
-    log_step 37 "Backend smoke test (all inference backends)"
+    log_step 38 "Backend smoke test (all inference backends)"
 
     # ── Load .env overrides (e.g. SMOKE_SKIP_VLLM=1) ──────────────────
     # Supported skip variables:
@@ -5058,8 +5061,89 @@ clone_and_build_lemonade() {
     success "Both ROCm and Vulkan backends ready for Lemonade"
 }
 
+clone_and_build_stable_diffusion() {
+    log_step 35 "Clone and build stable-diffusion.cpp with Vulkan"
+
+    clone_pkg stable_diffusion_cpp "${STABLE_DIFFUSION_SRC}" "stable-diffusion.cpp"
+
+    local _build_dir="${STABLE_DIFFUSION_SRC}/build-vulkan"
+
+    if [[ -x "${_build_dir}/bin/sd-cli" && -x "${_build_dir}/bin/sd-server" ]]; then
+        info "stable-diffusion.cpp Vulkan already built at ${_build_dir}/bin"
+    else
+        info "Building stable-diffusion.cpp with Vulkan backend..."
+
+        local _cc="${LOCAL_PREFIX}/lib/llvm/bin/amdclang"
+        local _cxx="${LOCAL_PREFIX}/lib/llvm/bin/amdclang++"
+
+        local _cpu_flags
+        if [[ ! -x "${_cc}" ]]; then
+            warn "TheRock amdclang not found at ${_cc}, falling back to system clang"
+            _cc="clang"
+            _cxx="clang++"
+            _cpu_flags="-O3 -DNDEBUG -march=native -flto=thin -mprefer-vector-width=512 -Wno-error=unused-command-line-argument"
+        else
+            _cpu_flags="-O3 -DNDEBUG -march=native -flto=thin -mprefer-vector-width=512 -mavx512f -mavx512dq -mavx512vl -mavx512bw -famd-opt -mllvm -polly -mllvm -polly-vectorizer=stripmine -mllvm -inline-threshold=600 -mllvm -unroll-threshold=150 -mllvm -adce-remove-loops -Wno-error=unused-command-line-argument"
+        fi
+
+        local _link_flags="-flto=thin -fuse-ld=lld -Wl,-rpath,${LOCAL_PREFIX}/lib -L${LOCAL_PREFIX}/lib -lalm"
+
+        cmake -B "${_build_dir}" -S "${STABLE_DIFFUSION_SRC}" \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="${_cc}" \
+            -DCMAKE_CXX_COMPILER="${_cxx}" \
+            -DCMAKE_C_FLAGS="${_cpu_flags}" \
+            -DCMAKE_CXX_FLAGS="${_cpu_flags}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${_link_flags}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${_link_flags}" \
+            -DSD_VULKAN=ON \
+            -DSD_BUILD_EXAMPLES=ON \
+            -DSD_BUILD_SHARED_LIBS=OFF \
+            -DSD_WEBP=ON \
+            -DSD_WEBM=ON \
+            -DGGML_NATIVE=ON \
+            -DGGML_OPENMP=ON \
+            -DGGML_CCACHE=ON \
+            -DGGML_VULKAN_CHECK_RESULTS=OFF \
+            -DGGML_VULKAN_VALIDATE=OFF \
+            -DGGML_VULKAN_DEBUG=OFF
+
+        cmake --build "${_build_dir}" --config Release -j "$(nproc)"
+        success "stable-diffusion.cpp Vulkan build complete"
+    fi
+
+    mkdir -p "${STABLE_DIFFUSION_VULKAN_DIR}"
+
+    local _binaries=(sd-cli sd-server)
+    for _bin in "${_binaries[@]}"; do
+        if [[ -x "${_build_dir}/bin/${_bin}" ]]; then
+            cp -f "${_build_dir}/bin/${_bin}" "${STABLE_DIFFUSION_VULKAN_DIR}/${_bin}"
+            info "Installed ${_bin} -> ${STABLE_DIFFUSION_VULKAN_DIR}/${_bin}"
+        else
+            warn "${_bin} not found in stable-diffusion.cpp build output"
+        fi
+    done
+
+    if command -v patchelf >/dev/null 2>&1; then
+        for _bin in "${_binaries[@]}"; do
+            [[ -x "${STABLE_DIFFUSION_VULKAN_DIR}/${_bin}" ]] || continue
+            patchelf --set-rpath "${LOCAL_PREFIX}/lib:${STABLE_DIFFUSION_VULKAN_DIR}" \
+                "${STABLE_DIFFUSION_VULKAN_DIR}/${_bin}"
+        done
+        info "RPATH fixed for stable-diffusion.cpp binaries"
+    fi
+
+    local _sd_version
+    _sd_version="$(cd "${STABLE_DIFFUSION_SRC}" && git describe --tags --always 2>/dev/null || echo "master")"
+    echo "${_sd_version}" > "${STABLE_DIFFUSION_VULKAN_DIR}/version.txt"
+    echo "vulkan" > "${STABLE_DIFFUSION_VULKAN_DIR}/backend.txt"
+
+    success "stable-diffusion.cpp Vulkan installed at ${STABLE_DIFFUSION_VULKAN_DIR}"
+}
+
 install_lemonade_sdk() {
-    log_step 35 "Install Lemonade SDK"
+    log_step 36 "Install Lemonade SDK"
 
     # The Lemonade project split in v10: the git repo (v10.0.0) is a C++ server,
     # while the Python SDK is published separately as lemonade-sdk on PyPI (v9.1.4).
@@ -5127,7 +5211,7 @@ print(f'  llama-server (vulkan): {path}')
 }
 
 validate_lemonade() {
-    log_step 36 "Validate Lemonade installation"
+    log_step 37 "Validate Lemonade and stable-diffusion.cpp installation"
 
     # Check llama-server binary
     if [[ ! -x "${LLAMACPP_INSTALL_DIR}/llama-server" ]]; then
@@ -5217,7 +5301,25 @@ assert importlib.util.find_spec('lemonade') or importlib.util.find_spec('lemonad
         warn "Only ROCm backend available — Vulkan will not be usable for >32K context"
     fi
 
-    success "Lemonade validation complete (ROCm + Vulkan)"
+    # --- Validate stable-diffusion.cpp Vulkan backend ---
+    info "Checking stable-diffusion.cpp Vulkan backend..."
+    if [[ -x "${STABLE_DIFFUSION_VULKAN_DIR}/sd-cli" ]]; then
+        success "sd-cli (vulkan): ${STABLE_DIFFUSION_VULKAN_DIR}/sd-cli"
+        "${STABLE_DIFFUSION_VULKAN_DIR}/sd-cli" -h >/dev/null 2>&1 \
+            || warn "sd-cli help check returned non-zero"
+        if [[ -f "${STABLE_DIFFUSION_VULKAN_DIR}/version.txt" ]]; then
+            info "stable-diffusion.cpp version: $(cat "${STABLE_DIFFUSION_VULKAN_DIR}/version.txt")"
+        fi
+    else
+        warn "sd-cli not found at ${STABLE_DIFFUSION_VULKAN_DIR}/sd-cli"
+    fi
+    if [[ -x "${STABLE_DIFFUSION_VULKAN_DIR}/sd-server" ]]; then
+        success "sd-server (vulkan): ${STABLE_DIFFUSION_VULKAN_DIR}/sd-server"
+    else
+        warn "sd-server not found at ${STABLE_DIFFUSION_VULKAN_DIR}/sd-server"
+    fi
+
+    success "Lemonade validation complete (ROCm + Vulkan + stable-diffusion.cpp)"
 }
 
 # =============================================================================

--- a/strix-halo/vllm-env.sh
+++ b/strix-halo/vllm-env.sh
@@ -386,7 +386,15 @@ if [[ -d "${_LLAMACPP_VULKAN}" ]]; then
     export LEMONADE_LLAMACPP_VULKAN_DIR="${_LLAMACPP_VULKAN}"
     export LD_LIBRARY_PATH="${_LLAMACPP_VULKAN}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 fi
-unset _LLAMACPP_ROCM _LLAMACPP_VULKAN
+
+# stable-diffusion.cpp Vulkan backend (image generation)
+_STABLE_DIFFUSION_VULKAN="${VLLM_VENV}/vulkan/stable_diffusion"
+if [[ -d "${_STABLE_DIFFUSION_VULKAN}" ]]; then
+    export STABLE_DIFFUSION_CPP_DIR="${_STABLE_DIFFUSION_VULKAN}"
+    export PATH="${_STABLE_DIFFUSION_VULKAN}:${PATH}"
+    export LD_LIBRARY_PATH="${_STABLE_DIFFUSION_VULKAN}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
+unset _LLAMACPP_ROCM _LLAMACPP_VULKAN _STABLE_DIFFUSION_VULKAN
 
 # =============================================================================
 # Virtual Environment Activation
@@ -475,6 +483,11 @@ if [[ "${1:-}" == "--info" ]]; then
     else
         echo "    Vulkan .env:      not found"
     fi
+    echo ""
+    echo "  stable-diffusion.cpp:"
+    echo "    Vulkan backend:   ${STABLE_DIFFUSION_CPP_DIR:-<not built>}"
+    echo "    sd-cli:           $(command -v sd-cli 2>/dev/null || echo 'not in PATH')"
+    echo "    sd-server:        $(command -v sd-server 2>/dev/null || echo 'not in PATH')"
     echo ""
     echo "  Runtime:"
     echo "    VENV active:      $(command -v python 2>/dev/null || echo 'no')"

--- a/strix-halo/vllm-packages.yaml
+++ b/strix-halo/vllm-packages.yaml
@@ -89,7 +89,7 @@ platform:
 
 build:
   vllm_dir: "/opt/src/vllm"
-  total_steps: 37
+  total_steps: 38
   cpython_version: "3.13.12"
   disk_required_gb: 100
   clang_min_version: 21
@@ -236,11 +236,12 @@ steps:
 
   # Phase I: Lemonade Inference Server
   34: clone_and_build_lemonade
-  35: install_lemonade_sdk
-  36: validate_lemonade
+  35: clone_and_build_stable_diffusion
+  36: install_lemonade_sdk
+  37: validate_lemonade
 
   # Phase J: Backend Smoke Test (all inference backends)
-  37: backend_smoke_test
+  38: backend_smoke_test
 
 # =============================================================================
 # Packages: per-component metadata (repos, patches, build notes)
@@ -1714,3 +1715,46 @@ packages:
       - "python -c 'import lemonade'"
       - "test -x ${VLLM_VENV}/rocm/llama_server/llama-server"
       - "test -x ${VLLM_VENV}/vulkan/llama_server/llama-server"
+
+  stable_diffusion_cpp:
+    repo: "https://github.com/leejet/stable-diffusion.cpp.git"
+    branch: "master"
+    recursive: true
+    src_dir: "vendor/stable-diffusion.cpp"
+    method: cmake
+    phase: I
+    steps: [35, 37]
+    depends_on: [therock]
+    compiler: amdclang
+    skip_marker: null
+    backend:
+      install_dir: "${VLLM_VENV}/vulkan/stable_diffusion"
+      build_dir: "build-vulkan"
+      cmake_flags:
+        SD_VULKAN: "ON"
+        SD_BUILD_EXAMPLES: "ON"
+        SD_BUILD_SHARED_LIBS: "OFF"
+        SD_WEBP: "ON"
+        SD_WEBM: "ON"
+        GGML_NATIVE: "ON"
+        GGML_OPENMP: "ON"
+        GGML_CCACHE: "ON"
+        GGML_VULKAN_CHECK_RESULTS: "OFF"
+        GGML_VULKAN_VALIDATE: "OFF"
+        GGML_VULKAN_DEBUG: "OFF"
+    binaries:
+      - sd-cli
+      - sd-server
+    notes: |
+      stable-diffusion.cpp built from upstream master with recursive ggml and
+      media submodules. The gfx1151 path uses the Vulkan backend because it is
+      the most practical Strix Halo image-generation backend: it avoids ROCm
+      device support gaps while still using the iGPU and unified memory.
+
+      Build options mirror the validated /opt/src/vllm/vendor build:
+      amdclang from TheRock, Zen 5 native CPU flags, ThinLTO, AOCL-LibM RPATH,
+      OpenMP CPU backend, WebP/WebM output support, and static stable-diffusion
+      libraries with standalone sd-cli/sd-server binaries.
+    validation:
+      - "test -x ${VLLM_VENV}/vulkan/stable_diffusion/sd-cli"
+      - "test -x ${VLLM_VENV}/vulkan/stable_diffusion/sd-server"


### PR DESCRIPTION
This pull request adds support for building and validating the `stable-diffusion.cpp` Vulkan backend for image generation as part of the Strix Halo vLLM pipeline. The build pipeline is extended by one step, and new environment variables and validation checks are introduced to integrate `stable-diffusion.cpp` alongside existing inference backends.

**Build pipeline and integration changes:**

- Added a new build step for cloning and building `stable-diffusion.cpp` with Vulkan backend, using Zen 5 native CPU flags, ThinLTO, AOCL-LibM, OpenMP, and support for WebP/WebM outputs. The binaries `sd-cli` and `sd-server` are installed into the venv at `${VLLM_VENV}/vulkan/stable_diffusion`. [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R5064-R5146) [[2]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaR146-R153) [[3]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1718-R1760)
- Updated the build pipeline from 37 to 38 steps, with the new steps reflected in documentation, scripts, and configuration files. [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4L32-R32) [[2]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4L76-R81) [[3]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL123-R128) [[4]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL253-R262) [[5]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eL92-R92) [[6]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eL239-R244)

**Validation and environment updates:**

- Enhanced the Lemonade validation step to also check for the presence and functionality of the `stable-diffusion.cpp` Vulkan backend, including version reporting and binary checks. [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4L5130-R5214) [[2]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4L5220-R5322)
- Updated the venv activation script to export paths and environment variables for the `stable-diffusion.cpp` Vulkan backend, ensuring binaries are accessible and libraries are in the runtime path.
- Improved the `--info` output in the venv activation script to display the status and location of the `stable-diffusion.cpp` backend and its binaries.

**Documentation and metadata:**

- Updated the README and package manifest to document the new backend, its build configuration, and its role in the pipeline. [[1]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaR290) [[2]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaR146-R153) [[3]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1718-R1760)

These changes enable image generation via `stable-diffusion.cpp` on Strix Halo systems, complementing existing LLM inference backends and improving the pipeline's versatility.