### PR TITLE
Tighten llama.cpp Vulkan build optimizations

### DIFF
--- a/strix-halo/README.md
+++ b/strix-halo/README.md
@@ -137,7 +137,11 @@ two GPU backends, managed by the
 | Backend | Best For | Notes |
 |---------|----------|-------|
 | **ROCm** (hipBLAS) | Prefill < 32K context | Primary backend, uses amdclang + gfx1151 HIP flags |
-| **Vulkan** | Generation speed, prefill > 32K | +22% tok/s generation, no 32K VMM limitation |
+| **Vulkan** | Generation speed, prefill > 32K | amdclang + Zen 5 flags, +22% tok/s generation, no 32K VMM limitation |
+
+Both builds use TheRock `amdclang`, Zen 5 native CPU flags, ThinLTO/ggml LTO,
+and omit the embedded llama-server web UI. The Vulkan build also links against
+AOCL-LibM and keeps Vulkan validation/debug checks disabled for release use.
 
 Both backends are installed into the venv and Lemonade can route between
 them based on workload. Each backend gets its own `.env` file with
@@ -148,7 +152,7 @@ gfx1151 runtime optimizations (batch sizing, hipBLASLt, THP).
 Phase I also builds [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp)
 from upstream `master` with the Vulkan backend for Strix Halo image generation.
 The build uses TheRock `amdclang`, Zen 5 native CPU flags, ThinLTO, AOCL-LibM,
-OpenMP, WebP/WebM support, and installs `sd-cli`/`sd-server` into
+ggml LTO, OpenMP, WebP/WebM support, and installs `sd-cli`/`sd-server` into
 `${VLLM_VENV}/vulkan/stable_diffusion`.
 
 ## Supported Distributions

--- a/strix-halo/build-vllm.sh
+++ b/strix-halo/build-vllm.sh
@@ -4913,6 +4913,7 @@ clone_and_build_lemonade() {
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_HIP=ON \
             -DAMDGPU_TARGETS="gfx1151" \
+            -DGGML_LTO=ON \
             -DCMAKE_C_COMPILER="${_cc}" \
             -DCMAKE_CXX_COMPILER="${_cxx}" \
             -DCMAKE_HIP_COMPILER="${_cxx}" \
@@ -4924,6 +4925,7 @@ clone_and_build_lemonade() {
             -DLLAMA_BUILD_SERVER=ON \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_BUILD_WEBUI=OFF \
             -DCMAKE_INSTALL_PREFIX="${LLAMACPP_INSTALL_DIR}"
 
         cmake --build "${_build_dir}" --config Release -j "$(nproc)"
@@ -5001,17 +5003,39 @@ clone_and_build_lemonade() {
     else
         info "Building llama.cpp with Vulkan backend..."
 
+        local _vulkan_cc="${LOCAL_PREFIX}/lib/llvm/bin/amdclang"
+        local _vulkan_cxx="${LOCAL_PREFIX}/lib/llvm/bin/amdclang++"
+
+        local _vulkan_cpu_flags
+        if [[ ! -x "${_vulkan_cc}" ]]; then
+            warn "TheRock amdclang not found at ${_vulkan_cc}, falling back to system clang"
+            _vulkan_cc="clang"
+            _vulkan_cxx="clang++"
+            _vulkan_cpu_flags="-O3 -DNDEBUG -march=native -flto=thin -mprefer-vector-width=512 -Wno-error=unused-command-line-argument"
+        else
+            _vulkan_cpu_flags="-O3 -DNDEBUG -march=native -flto=thin -mprefer-vector-width=512 -mavx512f -mavx512dq -mavx512vl -mavx512bw -famd-opt -mllvm -polly -mllvm -polly-vectorizer=stripmine -mllvm -inline-threshold=600 -mllvm -unroll-threshold=150 -mllvm -adce-remove-loops -Wno-error=unused-command-line-argument"
+        fi
+
+        local _vulkan_link_flags="-flto=thin -fuse-ld=lld -Wl,-rpath,${LOCAL_PREFIX}/lib -L${LOCAL_PREFIX}/lib -lalm"
+
         cmake -B "${_vulkan_build_dir}" -S "${LLAMACPP_SRC}" \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_VULKAN=ON \
-            -DCMAKE_C_FLAGS_RELEASE="-O3 -march=native -flto=thin -mprefer-vector-width=512" \
-            -DCMAKE_CXX_FLAGS_RELEASE="-O3 -march=native -flto=thin -mprefer-vector-width=512" \
-            -DCMAKE_EXE_LINKER_FLAGS="-flto=thin -fuse-ld=lld" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-flto=thin -fuse-ld=lld" \
+            -DGGML_LTO=ON \
+            -DGGML_VULKAN_CHECK_RESULTS=OFF \
+            -DGGML_VULKAN_VALIDATE=OFF \
+            -DGGML_VULKAN_DEBUG=OFF \
+            -DCMAKE_C_COMPILER="${_vulkan_cc}" \
+            -DCMAKE_CXX_COMPILER="${_vulkan_cxx}" \
+            -DCMAKE_C_FLAGS="${_vulkan_cpu_flags}" \
+            -DCMAKE_CXX_FLAGS="${_vulkan_cpu_flags}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${_vulkan_link_flags}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${_vulkan_link_flags}" \
             -DLLAMA_BUILD_SERVER=ON \
             -DLLAMA_BUILD_TESTS=OFF \
-            -DLLAMA_BUILD_EXAMPLES=OFF
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_BUILD_WEBUI=OFF
 
         cmake --build "${_vulkan_build_dir}" --config Release -j "$(nproc)"
         success "llama.cpp Vulkan build complete"
@@ -5042,9 +5066,9 @@ clone_and_build_lemonade() {
     if command -v patchelf >/dev/null 2>&1; then
         for _bin in "${_binaries[@]}"; do
             [[ -x "${LLAMACPP_VULKAN_DIR}/${_bin}" ]] || continue
-            patchelf --set-rpath "${LLAMACPP_VULKAN_DIR}" "${LLAMACPP_VULKAN_DIR}/${_bin}"
+            patchelf --set-rpath "${LOCAL_PREFIX}/lib:${LLAMACPP_VULKAN_DIR}" "${LLAMACPP_VULKAN_DIR}/${_bin}"
         done
-        info "RPATH fixed for Vulkan binaries -> ${LLAMACPP_VULKAN_DIR}"
+        info "RPATH fixed for Vulkan binaries -> ${LOCAL_PREFIX}/lib:${LLAMACPP_VULKAN_DIR}"
     fi
 
     # Version tracking for Vulkan backend
@@ -5103,6 +5127,7 @@ clone_and_build_stable_diffusion() {
             -DSD_WEBP=ON \
             -DSD_WEBM=ON \
             -DGGML_NATIVE=ON \
+            -DGGML_LTO=ON \
             -DGGML_OPENMP=ON \
             -DGGML_CCACHE=ON \
             -DGGML_VULKAN_CHECK_RESULTS=OFF \

--- a/strix-halo/vllm-packages.yaml
+++ b/strix-halo/vllm-packages.yaml
@@ -1638,6 +1638,8 @@ packages:
         cmake_flags:
           GGML_HIP: "ON"
           AMDGPU_TARGETS: "gfx1151"
+          GGML_LTO: "ON"
+          LLAMA_BUILD_WEBUI: "OFF"
         hip_flags: "--offload-arch=gfx1151 -mllvm -amdgpu-function-calls=false -mllvm -amdgpu-early-inline-all=true -famd-opt"
         env:
           HSA_OVERRIDE_GFX_VERSION: "11.5.1"
@@ -1650,6 +1652,11 @@ packages:
         build_dir: "build-vulkan"
         cmake_flags:
           GGML_VULKAN: "ON"
+          GGML_LTO: "ON"
+          GGML_VULKAN_CHECK_RESULTS: "OFF"
+          GGML_VULKAN_VALIDATE: "OFF"
+          GGML_VULKAN_DEBUG: "OFF"
+          LLAMA_BUILD_WEBUI: "OFF"
         env:
           LLAMA_ARG_BATCH: "2048"
           LLAMA_ARG_UBATCH: "2048"
@@ -1667,11 +1674,13 @@ packages:
 
       ROCm (hipBLAS): Primary backend. Best prefill <32K context. Uses
       amdclang from TheRock with full Zen 5 + gfx1151 HIP optimization
-      flags. Binaries placed where Lemonade SDK expects them.
+      flags, explicit ggml LTO, and no embedded server web UI. Binaries placed
+      where Lemonade SDK expects them.
 
       Vulkan: Secondary backend. +22% generation speed (44 vs 39 tok/s)
       and handles >32K context prefill (no VMM limitation on gfx1151).
-      CPU-only optimization flags, no HIP offload.
+      Uses the same amdclang, Zen 5, ThinLTO, AOCL-LibM, and Vulkan
+      release-mode settings as the stable-diffusion.cpp Vulkan build.
 
       Both backends get .env files with gfx1151 runtime optimizations
       (batch sizing, hipBLASLt, THP). RPATH patched via patchelf so
@@ -1737,6 +1746,7 @@ packages:
         SD_WEBP: "ON"
         SD_WEBM: "ON"
         GGML_NATIVE: "ON"
+        GGML_LTO: "ON"
         GGML_OPENMP: "ON"
         GGML_CCACHE: "ON"
         GGML_VULKAN_CHECK_RESULTS: "OFF"


### PR DESCRIPTION
This pull request enhances the build process and documentation for both ROCm (hipBLAS) and Vulkan backends, focusing on improved performance, explicit optimization flags, and clearer configuration. The changes ensure both backends use consistent compiler settings (TheRock `amdclang`, Zen 5 flags, ThinLTO/LTO), disable the embedded web UI, and optimize runtime linking and validation options for release builds.

**Build and Optimization Improvements:**

* Both ROCm and Vulkan builds now explicitly enable GGML LTO (link-time optimization) and use TheRock `amdclang` with Zen 5 CPU flags for maximum performance. The Vulkan build also links against AOCL-LibM and disables validation/debug checks for release use. (`build-vllm.sh`, `vllm-packages.yaml`, `README.md`) [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R4916) [[2]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R5006-R5038) [[3]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1641-R1642) [[4]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1655-R1659) [[5]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL140-R144) [[6]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eL1670-R1683)
* The embedded llama-server web UI is now disabled in all builds to streamline binaries and reduce unnecessary dependencies. (`build-vllm.sh`, `vllm-packages.yaml`, `README.md`) [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R4928) [[2]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R5006-R5038) [[3]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1641-R1642) [[4]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1655-R1659) [[5]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL140-R144) [[6]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eL1670-R1683)

**Vulkan Backend Specifics:**

* Vulkan backend builds now use explicit CPU flags, improved linker flags, and AOCL-LibM, with all validation and debug checks turned off for optimized release binaries. (`build-vllm.sh`, `vllm-packages.yaml`, `README.md`) [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R5006-R5038) [[2]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1655-R1659) [[3]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL140-R144) [[4]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eL1670-R1683)
* RPATH for Vulkan binaries is updated to include both `${LOCAL_PREFIX}/lib` and the binary directory, ensuring proper runtime library resolution. (`build-vllm.sh`)

**Stable Diffusion Build:**

* The stable-diffusion.cpp build now also enables GGML LTO for improved performance and consistency with the rest of the stack. (`build-vllm.sh`, `vllm-packages.yaml`, `README.md`) [[1]](diffhunk://#diff-8398bc5400776902dc3a075b131fe59554379be68f02b92931fde416521a78d4R5130) [[2]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eR1749) [[3]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL151-R155)

**Documentation Updates:**

* The `README.md` and `vllm-packages.yaml` documentation are updated to reflect these build and optimization changes, clarifying backend differences and build settings. [[1]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL140-R144) [[2]](diffhunk://#diff-d31e359caa8446d8c1e50d9438372e3308749d58f604454cf88324cfb2e6cbbaL151-R155) [[3]](diffhunk://#diff-c87ac1c2f075dab97bd1ff243c28ad465f24ef1c477f7b0f85fe106ac3c5936eL1670-R1683)

These changes collectively improve performance, maintainability, and clarity for developers and users working with the ROCm and Vulkan backends.